### PR TITLE
[feat] User 모델 재정의

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,12 @@ or
 $ npm start
 ```
 
+## 테스트
+```
+$ yarn test
+or
+$ npm test
+```
+
 ## 라이센스
 MIT

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/jhs851/muscleman-api#readme",
   "dependencies": {
     "apollo-server": "^3.3.0",
+    "bcrypt": "^5.0.1",
     "class-validator": "^0.13.1",
     "graphql": "^15.5.3",
     "mongoose": "^6.0.6",
@@ -29,8 +30,10 @@
   },
   "devDependencies": {
     "@typegoose/typegoose": "^8.3.0",
+    "@types/bcrypt": "^5.0.0",
     "@types/faker": "^5.5.8",
     "@types/jest": "^27.0.1",
+    "@types/mongoose": "^5.11.97",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "dotenv": "^10.0.0",

--- a/src/factories/UserFactory.ts
+++ b/src/factories/UserFactory.ts
@@ -15,8 +15,10 @@ export const UserFactory: (input?: UserFactoryInput) => UserInput = input => {
       nickname: faker.unique(faker.name.firstName),
       password,
       password_confirmation: password,
-      age: faker.datatype.number(UserLimit.age),
       gender: faker.random.arrayElement(['male', 'female']),
+      birth: faker.date
+        .between(UserLimit.birth.minDate, UserLimit.birth.maxDate)
+        .toISOString(),
       height: faker.datatype.number(UserLimit.height),
       weight: faker.datatype.number(UserLimit.weight),
       fat: faker.datatype.number({ min: 10, max: 50 }),

--- a/src/factories/UserFactory.ts
+++ b/src/factories/UserFactory.ts
@@ -1,10 +1,29 @@
-import * as faker from 'faker';
+import faker from 'faker';
 import { UserFactoryInput } from '@src/factories/types/UserFactoryInput';
 import { UserInput } from '@src/resolvers/types/UserInput';
-import { User } from '@src/models/User';
+import { UserLimit } from '@src/limits/UserLimit';
 
-export const UserFactory: (input?: UserFactoryInput) => UserInput = input =>
-  ({
-    name: input?.name || faker.name.findName(),
-    email: input?.email || faker.internet.email(),
-  } as User);
+export const UserFactory: (input?: UserFactoryInput) => UserInput = input => {
+  const password = faker.random.words(4);
+
+  return Object.assign(
+    {
+      name: faker.name.lastName() + faker.name.firstName(),
+      email: `${faker.unique(faker.random.words, [1])}@${
+        faker.internet.email().split('@')[1]
+      }`,
+      nickname: faker.unique(faker.name.firstName),
+      password,
+      password_confirmation: password,
+      age: faker.datatype.number(UserLimit.age),
+      gender: faker.random.arrayElement(['male', 'female']),
+      height: faker.datatype.number(UserLimit.height),
+      weight: faker.datatype.number(UserLimit.weight),
+      fat: faker.datatype.number({ min: 10, max: 50 }),
+      muscle: faker.datatype.number({ min: 10, max: 150 }),
+      tel: faker.phone.phoneNumber('010-####-####'),
+      profile_image_path: faker.image.imageUrl(64, 64),
+    },
+    input,
+  ) as UserInput;
+};

--- a/src/factories/types/UserFactoryInput.ts
+++ b/src/factories/types/UserFactoryInput.ts
@@ -1,11 +1,96 @@
-import { Field, InputType } from 'type-graphql';
+import { Field, InputType, Int } from 'type-graphql';
 import { User } from '@src/models/User';
+import { Gender } from '@src/types/enums';
+import {
+  IsEmail,
+  IsEnum,
+  IsInt,
+  IsMobilePhone,
+  IsOptional,
+  IsString,
+  Length,
+  Max,
+  Min,
+  MinLength,
+} from 'class-validator';
+import { UserLimit } from '@src/limits/UserLimit';
 
 @InputType({ description: '사용자 팩토리 입력 객체' })
 export class UserFactoryInput implements Partial<User> {
-  @Field({ nullable: true })
+  @Field(() => String, { description: '이름', nullable: true })
+  @IsOptional()
+  @IsString()
+  @Length(UserLimit.name.minLength, UserLimit.name.maxLength)
   name?: string;
 
-  @Field({ nullable: true })
+  @Field(() => String, { description: '이메일', nullable: true })
+  @IsOptional()
+  @IsString()
+  @IsEmail({ allow_utf8_local_part: true })
   email?: string;
+
+  @Field(() => String, { description: '닉네임', nullable: true })
+  @IsOptional()
+  @IsString()
+  @Length(UserLimit.nickname.minLength, UserLimit.nickname.maxLength)
+  nickname?: string;
+
+  @Field(() => String, { description: '비밀번호', nullable: true })
+  @IsOptional()
+  @IsString()
+  @MinLength(UserLimit.password.minLength)
+  password?: string;
+
+  @Field(() => String, { description: '비밀번호 확인', nullable: true })
+  @IsOptional()
+  @IsString()
+  @MinLength(UserLimit.password.minLength)
+  password_confirmation?: string;
+
+  @Field(() => Int, { description: '나이', nullable: true })
+  @IsOptional()
+  @IsInt()
+  @Min(UserLimit.age.min)
+  @Max(UserLimit.age.max)
+  age?: number;
+
+  @Field(() => Gender, { description: '성별', nullable: true })
+  @IsOptional()
+  @IsEnum(Gender)
+  gender?: Gender;
+
+  @Field(() => Int, { description: '키', nullable: true })
+  @IsOptional()
+  @IsInt()
+  @Min(UserLimit.height.min)
+  @Max(UserLimit.height.max)
+  height?: number;
+
+  @Field(() => Int, { description: '몸무게', nullable: true })
+  @IsOptional()
+  @IsInt()
+  @Min(UserLimit.weight.min)
+  @Max(UserLimit.weight.max)
+  weight?: number;
+
+  @Field(() => Int, { description: '체지방량(kg)', nullable: true })
+  @IsOptional()
+  @IsInt()
+  fat?: number;
+
+  @Field(() => Int, { description: '골격근량(kg)', nullable: true })
+  @IsOptional()
+  @IsInt()
+  muscle?: number;
+
+  @Field(() => String, { description: '휴대폰번호', nullable: true })
+  @IsOptional()
+  @IsString()
+  @IsMobilePhone('ko-KR')
+  tel?: string;
+
+  @Field(() => String, { description: '프로필 이미지 경로', nullable: true })
+  @IsOptional()
+  @IsString()
+  profile_image_path?: string;
 }

--- a/src/factories/types/UserFactoryInput.ts
+++ b/src/factories/types/UserFactoryInput.ts
@@ -2,6 +2,7 @@ import { Field, InputType, Int } from 'type-graphql';
 import { User } from '@src/models/User';
 import { Gender } from '@src/types/enums';
 import {
+  IsDate,
   IsEmail,
   IsEnum,
   IsInt,
@@ -10,7 +11,9 @@ import {
   IsString,
   Length,
   Max,
+  MaxDate,
   Min,
+  MinDate,
   MinLength,
 } from 'class-validator';
 import { UserLimit } from '@src/limits/UserLimit';
@@ -47,17 +50,17 @@ export class UserFactoryInput implements Partial<User> {
   @MinLength(UserLimit.password.minLength)
   password_confirmation?: string;
 
-  @Field(() => Int, { description: '나이', nullable: true })
-  @IsOptional()
-  @IsInt()
-  @Min(UserLimit.age.min)
-  @Max(UserLimit.age.max)
-  age?: number;
-
   @Field(() => Gender, { description: '성별', nullable: true })
   @IsOptional()
   @IsEnum(Gender)
   gender?: Gender;
+
+  @Field(() => Date, { description: '생년월일', nullable: true })
+  @IsOptional()
+  @IsDate()
+  @MinDate(UserLimit.birth.minDate)
+  @MaxDate(UserLimit.birth.maxDate)
+  birth?: Date | string;
 
   @Field(() => Int, { description: '키', nullable: true })
   @IsOptional()

--- a/src/limits/UserLimit.ts
+++ b/src/limits/UserLimit.ts
@@ -10,9 +10,9 @@ export const UserLimit = {
   password: {
     minLength: 8,
   },
-  age: {
-    min: 9,
-    max: 150,
+  birth: {
+    minDate: new Date(1900, 0, 1),
+    maxDate: new Date(new Date().getFullYear() - 8, 0, 1),
   },
   height: {
     min: 67,

--- a/src/limits/UserLimit.ts
+++ b/src/limits/UserLimit.ts
@@ -1,0 +1,25 @@
+export const UserLimit = {
+  name: {
+    minLength: 2,
+    maxLength: 6,
+  },
+  nickname: {
+    minLength: 2,
+    maxLength: 8,
+  },
+  password: {
+    minLength: 8,
+  },
+  age: {
+    min: 9,
+    max: 150,
+  },
+  height: {
+    min: 67,
+    max: 250,
+  },
+  weight: {
+    min: 30,
+    max: 350,
+  },
+};

--- a/src/models/Model.ts
+++ b/src/models/Model.ts
@@ -1,0 +1,17 @@
+import { Field, ID, InterfaceType } from 'type-graphql';
+import { prop } from '@typegoose/typegoose';
+import { ObjectId } from 'mongodb';
+
+@InterfaceType()
+export abstract class Model {
+  @Field(() => ID)
+  readonly _id: ObjectId;
+
+  @Field(() => Date, { description: '생성 날짜', defaultValue: new Date() })
+  @prop({ type: Date, default: new Date() })
+  created_at: Date;
+
+  @Field(() => Date, { description: '수정 날짜', defaultValue: new Date() })
+  @prop({ type: Date, default: new Date() })
+  updated_at: Date;
+}

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -21,13 +21,13 @@ export class User extends Model {
   @prop({ type: String })
   password?: string;
 
-  @Field(() => Int, { description: '나이', nullable: true })
-  @prop({ type: Number })
-  age?: number;
-
   @Field(() => Gender, { description: '성별' })
   @prop({ enum: Gender, type: String })
   gender: Gender;
+
+  @Field(() => Date, { description: '생년월일', nullable: true })
+  @prop({ type: Date })
+  birth?: Date | string;
 
   @Field(() => Int, { description: '키', nullable: true })
   @prop({ type: Number })

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,19 +1,57 @@
-import { Field, ID, ObjectType } from 'type-graphql';
-import { ObjectId } from 'mongodb';
+import { Field, Int, ObjectType } from 'type-graphql';
 import { getModelForClass, prop } from '@typegoose/typegoose';
+import { Gender } from '@src/types/enums';
+import { Model } from '@src/models/Model';
 
-@ObjectType({ description: '사용자 모델' })
-export class User {
-  @Field(() => ID)
-  readonly _id: ObjectId;
-
+@ObjectType({ implements: Model, description: '사용자 모델' })
+export class User extends Model {
   @Field(() => String, { description: '이름' })
-  @prop({ required: true })
+  @prop({ type: String, required: true })
   name: string;
 
   @Field(() => String, { description: '이메일' })
-  @prop({ required: true, unique: true })
+  @prop({ type: String, required: true, unique: true })
   email: string;
+
+  @Field(() => String, { description: '닉네임' })
+  @prop({ type: String, required: true, unique: true })
+  nickname: string;
+
+  @Field(() => String, { description: '비밀번호', nullable: true })
+  @prop({ type: String })
+  password?: string;
+
+  @Field(() => Int, { description: '나이', nullable: true })
+  @prop({ type: Number })
+  age?: number;
+
+  @Field(() => Gender, { description: '성별' })
+  @prop({ enum: Gender, type: String })
+  gender: Gender;
+
+  @Field(() => Int, { description: '키', nullable: true })
+  @prop({ type: Number })
+  height?: number;
+
+  @Field(() => Int, { description: '몸무게', nullable: true })
+  @prop({ type: Number })
+  weight?: number;
+
+  @Field(() => Int, { description: '체지방량(kg)', nullable: true })
+  @prop({ type: Number })
+  fat?: number;
+
+  @Field(() => Int, { description: '골격근량(kg)', nullable: true })
+  @prop({ type: Number })
+  muscle?: number;
+
+  @Field(() => String, { description: '휴대폰번호', nullable: true })
+  @prop({ type: String })
+  tel?: string;
+
+  @Field(() => String, { description: '프로필 이미지 경로', nullable: true })
+  @prop({ type: String })
+  profile_image_path: string;
 }
 
 export const UserModel = getModelForClass(User);

--- a/src/resolvers/UserResolver.ts
+++ b/src/resolvers/UserResolver.ts
@@ -3,6 +3,8 @@ import { Arg, Mutation, Query, Resolver } from 'type-graphql';
 import { UserInput } from '@src/resolvers/types/UserInput';
 import { ObjectIdScalar } from '@src/scalars/ObjectIdScalar';
 import { ObjectId } from 'mongodb';
+import bcrypt from 'bcrypt';
+import { UserInputError } from 'apollo-server';
 
 @Resolver(() => User)
 export class UserResolver {
@@ -11,17 +13,24 @@ export class UserResolver {
     return UserModel.find({});
   }
 
-  @Mutation(() => User, { description: '사용자 생성' })
-  async createUser(@Arg('input') userInput: UserInput): Promise<User> {
-    return UserModel.create(userInput);
+  @Query(() => User, { description: '특정 사용자 조회' })
+  async user(@Arg('_id', () => ObjectIdScalar) _id: ObjectId): Promise<User> {
+    const user = await UserModel.findById(_id).exec();
+
+    if (user === null) {
+      throw new Error(`사용자를 찾을 수 없습니다. _id: ${_id}`);
+    }
+
+    return user;
   }
 
-  @Mutation(() => Boolean, { description: '특정 사용자 삭제' })
-  async deleteUser(
-    @Arg('_id', () => ObjectIdScalar) _id: ObjectId,
-  ): Promise<boolean> {
-    await UserModel.deleteOne({ _id });
+  @Mutation(() => User, { description: '사용자 생성' })
+  async register(@Arg('input') input: UserInput): Promise<User> {
+    if (input.password !== input.password_confirmation) {
+      throw new UserInputError('비밀번호와 비밀번호 확인 값이 다릅니다');
+    }
+    input.password = await bcrypt.hash(input.password, 12);
 
-    return true;
+    return UserModel.create(input);
   }
 }

--- a/src/resolvers/types/UserInput.ts
+++ b/src/resolvers/types/UserInput.ts
@@ -1,11 +1,98 @@
-import { Field, InputType } from 'type-graphql';
+import { Field, InputType, Int } from 'type-graphql';
 import { User } from '@src/models/User';
+import { Gender } from '@src/types/enums';
+import {
+  IsDefined,
+  IsEmail,
+  IsEnum,
+  IsInt,
+  IsMobilePhone,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Length,
+  Max,
+  Min,
+  MinLength,
+} from 'class-validator';
+import { UserLimit } from '@src/limits/UserLimit';
 
 @InputType({ description: '사용자 입력 객체' })
 export class UserInput implements Partial<User> {
   @Field(() => String, { description: '이름' })
+  @IsDefined()
+  @IsString()
+  @Length(UserLimit.name.minLength, UserLimit.name.maxLength)
   name: string;
 
   @Field(() => String, { description: '이메일' })
+  @IsDefined()
+  @IsString()
+  @IsEmail()
   email: string;
+
+  @Field(() => String, { description: '닉네임' })
+  @IsDefined()
+  @IsString()
+  @Length(UserLimit.nickname.minLength, UserLimit.nickname.maxLength)
+  nickname: string;
+
+  @Field(() => String, { description: '비밀번호' })
+  @IsDefined()
+  @IsString()
+  @MinLength(UserLimit.password.minLength)
+  password: string;
+
+  @Field(() => String, { description: '비밀번호 확인' })
+  @IsDefined()
+  @IsString()
+  @MinLength(UserLimit.password.minLength)
+  password_confirmation: string;
+
+  @Field(() => Int, { description: '나이', nullable: true })
+  @IsOptional()
+  @IsInt()
+  @Min(UserLimit.age.min)
+  @Max(UserLimit.age.max)
+  age?: number;
+
+  @Field(() => Gender, { description: '성별' })
+  @IsDefined()
+  @IsEnum(Gender)
+  gender: Gender;
+
+  @Field(() => Int, { description: '키', nullable: true })
+  @IsOptional()
+  @IsInt()
+  @Min(UserLimit.height.min)
+  @Max(UserLimit.height.max)
+  height?: number;
+
+  @Field(() => Int, { description: '몸무게', nullable: true })
+  @IsOptional()
+  @IsInt()
+  @Min(UserLimit.weight.min)
+  @Max(UserLimit.weight.max)
+  weight?: number;
+
+  @Field(() => Int, { description: '체지방량(kg)', nullable: true })
+  @IsOptional()
+  @IsInt()
+  fat?: number;
+
+  @Field(() => Int, { description: '골격근량(kg)', nullable: true })
+  @IsOptional()
+  @IsInt()
+  muscle?: number;
+
+  @Field(() => String, { description: '휴대폰번호', nullable: true })
+  @IsOptional()
+  @IsString()
+  @IsMobilePhone('ko-KR')
+  tel?: string;
+
+  @Field(() => String, { description: '프로필 이미지 경로', nullable: true })
+  @IsOptional()
+  @IsUrl()
+  profile_image_path?: string;
 }

--- a/src/resolvers/types/UserInput.ts
+++ b/src/resolvers/types/UserInput.ts
@@ -2,6 +2,7 @@ import { Field, InputType, Int } from 'type-graphql';
 import { User } from '@src/models/User';
 import { Gender } from '@src/types/enums';
 import {
+  IsDate,
   IsDefined,
   IsEmail,
   IsEnum,
@@ -12,7 +13,9 @@ import {
   IsUrl,
   Length,
   Max,
+  MaxDate,
   Min,
+  MinDate,
   MinLength,
 } from 'class-validator';
 import { UserLimit } from '@src/limits/UserLimit';
@@ -49,17 +52,17 @@ export class UserInput implements Partial<User> {
   @MinLength(UserLimit.password.minLength)
   password_confirmation: string;
 
-  @Field(() => Int, { description: '나이', nullable: true })
-  @IsOptional()
-  @IsInt()
-  @Min(UserLimit.age.min)
-  @Max(UserLimit.age.max)
-  age?: number;
-
   @Field(() => Gender, { description: '성별' })
   @IsDefined()
   @IsEnum(Gender)
   gender: Gender;
+
+  @Field(() => Date, { description: '생년월일', nullable: true })
+  @IsOptional()
+  @IsDate()
+  @MinDate(UserLimit.birth.minDate)
+  @MaxDate(UserLimit.birth.maxDate)
+  birth?: Date;
 
   @Field(() => Int, { description: '키', nullable: true })
   @IsOptional()

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,12 +1,14 @@
-import { buildSchema } from 'type-graphql';
+import { buildSchema, registerEnumType } from 'type-graphql';
 import { TypegooseMiddleware } from '@src/middlewares/TypegooseMiddleware';
 import { ObjectId } from 'mongodb';
 import { ObjectIdScalar } from '@src/scalars/ObjectIdScalar';
 import { GraphQLSchema } from 'graphql';
+import { Gender } from '@src/types/enums';
+
+registerEnumType(Gender, { name: 'Gender', description: '성별' });
 
 export const schema: Promise<GraphQLSchema> = buildSchema({
   resolvers: [__dirname + '/**/resolvers/*Resolver.{ts,js}'],
   globalMiddlewares: [TypegooseMiddleware],
   scalarsMap: [{ type: ObjectId, scalar: ObjectIdScalar }],
-  validate: false,
 });

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,0 +1,4 @@
+export enum Gender {
+  male = 'male',
+  female = 'female',
+}

--- a/tests/feature/connect.test.ts
+++ b/tests/feature/connect.test.ts
@@ -1,57 +1,7 @@
 import mongoose from 'mongoose';
-import { graphql } from '@tests/graphql';
-import { UserFactory } from '@src/factories/UserFactory';
-import { UserInput } from '@src/resolvers/types/UserInput';
-import { UserModel } from '@src/models/User';
 
 describe('graphQL과 mongoDB를 연결한다', () => {
-  const user: UserInput = UserFactory();
-
   it('mongo 메모리 서버가 실행 중이다', () => {
     expect(mongoose.connection.readyState).toEqual(1);
-  });
-
-  it('graphQL로 데이터를 생성하고 읽을 수 있다', async () => {
-    const { data } = await graphql(
-      `
-        mutation createUser($name: String!, $email: String!) {
-          createUser(input: { name: $name, email: $email }) {
-            _id
-            name
-            email
-          }
-        }
-      `,
-      { ...user },
-    );
-
-    expect(await UserModel.exists(data?.createUser)).toBeTruthy();
-  });
-
-  it('graphQL에서 생성한 데이터를 mongo 메모리 서버에서 읽을 수 있다', async () => {
-    const users = mongoose.connection.collection('users');
-
-    expect(await users.count(user)).toBe(1);
-  });
-
-  it('graphQL로 데이터를 삭제할 수 있다', async () => {
-    const findOne = await UserModel.findOne({}).exec();
-    const { data } = await graphql(
-      `
-        mutation deleteUser($_id: ObjectId!) {
-          deleteUser(_id: $_id)
-        }
-      `,
-      { _id: findOne?._id.toString() },
-    );
-
-    expect(data?.deleteUser).toBeTruthy();
-    expect(await UserModel.exists(user)).toBeFalsy();
-  });
-
-  it('graphQL에서 삭제한 데이터를 mongo 메모리 서버에서 읽을 수 없다', async () => {
-    const users = mongoose.connection.collection('users');
-
-    expect(await users.count(user)).toBe(0);
   });
 });

--- a/tests/feature/get-users.test.ts
+++ b/tests/feature/get-users.test.ts
@@ -1,0 +1,41 @@
+import { graphql } from '@tests/graphql';
+import { UserModel } from '@src/models/User';
+import { UserFactory } from '@src/factories/UserFactory';
+
+describe('사용자 모델', () => {
+  it('모든 사용자를 조회할 수 있다', async () => {
+    const count = 5;
+
+    await Promise.all(
+      [...Array(count)].map(() => UserModel.create(UserFactory())),
+    );
+
+    const { data } = await graphql(
+      `
+        query users {
+          users {
+            _id
+          }
+        }
+      `,
+    );
+
+    expect(data?.users.length).toEqual(count);
+  });
+
+  it('특정 사용자를 조회할 수 있다', async () => {
+    const user = await UserModel.create(UserFactory());
+    const { data } = await graphql(
+      `
+        query user($_id: ObjectId!) {
+          user(_id: $_id) {
+            _id
+          }
+        }
+      `,
+      { _id: user._id.toString() },
+    );
+
+    expect(data?.user._id).toEqual(user._id.toString());
+  });
+});

--- a/tests/feature/registeration.test.ts
+++ b/tests/feature/registeration.test.ts
@@ -1,0 +1,288 @@
+import { UserFactory } from '@src/factories/UserFactory';
+import { graphql } from '@tests/graphql';
+import { UserLimit } from '@src/limits/UserLimit';
+import { GraphQLError } from 'graphql';
+import { UserModel } from '@src/models/User';
+import { ArgumentValidationError } from 'type-graphql';
+import { UserInputError } from 'apollo-server';
+import bcrypt from 'bcrypt';
+
+describe('회원가입을 할 수 있다', () => {
+  const registerMutation = `mutation register($input: UserInput!) { register(input: $input) { _id, password } }`;
+
+  // TODO: #7
+  // it('로그인한 사용자는 요청할 수 없다', () => {});
+
+  it('이름, 이메일, 닉네임, 비밀번호, 비밀번호 확인 필드는 반드시 필요하다', async () => {
+    await Promise.all(
+      ['name', 'email', 'nickname', 'password', 'password_confirmation'].map(
+        async field => {
+          const { errors } = await graphql(registerMutation, {
+            input: UserFactory({ [field]: '' }),
+          });
+
+          expect(errors).not.toBeUndefined();
+          if (errors) {
+            expect(errors.length).toEqual(1);
+            expect(errors[0].originalError).toBeInstanceOf(
+              ArgumentValidationError,
+            );
+          }
+        },
+      ),
+    );
+  });
+
+  it(`이름은 ${UserLimit.name.minLength}글자 이상 ${UserLimit.name.maxLength}글자 이하이어야 한다`, async () => {
+    await Promise.all(
+      Object.entries(UserLimit.name).map(async ([key, value]) => {
+        const { errors } = await graphql(registerMutation, {
+          input: UserFactory({
+            name: 'a'.repeat(value + (key === 'maxLength' ? 1 : -1)),
+          }),
+        });
+
+        expect(errors).not.toBeUndefined();
+        if (errors) {
+          expect(errors[0].originalError).toBeInstanceOf(
+            ArgumentValidationError,
+          );
+        }
+      }),
+    );
+  });
+
+  it('이메일 형식이 아닌 이메일은 사용할 수 없다', async () => {
+    const { errors } = await graphql(registerMutation, {
+      input: UserFactory({ email: 'HelloWorld' }),
+    });
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors[0].originalError).toBeInstanceOf(ArgumentValidationError);
+    }
+  });
+
+  it('이미 등록된 이메일은 사용할 수 없다', async () => {
+    const email = 'john@example.com';
+    await UserModel.create(UserFactory({ email }));
+    const { errors } = await graphql(registerMutation, {
+      input: UserFactory({ email }),
+    });
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].message).toContain('E11000 duplicate key error dup key');
+    }
+  });
+
+  it(`닉네임은 ${UserLimit.nickname.minLength}글자 이상 ${UserLimit.nickname.maxLength}글자 이하이어야 한다`, async () => {
+    await Promise.all(
+      Object.entries(UserLimit.nickname).map(async ([key, value]) => {
+        const { errors } = await graphql(registerMutation, {
+          input: UserFactory({
+            nickname: 'a'.repeat(value + (key === 'maxLength' ? 1 : -1)),
+          }),
+        });
+
+        expect(errors).not.toBeUndefined();
+        if (errors) {
+          expect(errors[0].originalError).toBeInstanceOf(
+            ArgumentValidationError,
+          );
+        }
+      }),
+    );
+  });
+
+  it('이미 등록된 닉네임은 사용할 수 없다', async () => {
+    const nickname = '근육맨';
+    await UserModel.create(UserFactory({ nickname }));
+    const { errors } = await graphql(registerMutation, {
+      input: UserFactory({ nickname }),
+    });
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].message).toContain('E11000 duplicate key error dup key');
+    }
+  });
+
+  it(`비밀번호와 비밀번호 확인은 ${UserLimit.password.minLength}글자 이상이어야 한다`, async () => {
+    await Promise.all(
+      ['password', 'password_confirmation'].map(async field => {
+        const { errors } = await graphql(registerMutation, {
+          input: UserFactory({
+            [field]: 'a'.repeat(UserLimit.password.minLength - 1),
+          }),
+        });
+
+        expect(errors).not.toBeUndefined();
+        if (errors) {
+          expect(errors[0].originalError).toBeInstanceOf(
+            ArgumentValidationError,
+          );
+        }
+      }),
+    );
+  });
+
+  it('비밀번호와 비밀번호 확인 값은 같아야 한다', async () => {
+    const { errors } = await graphql(registerMutation, {
+      input: UserFactory({
+        password: 'It is password',
+        password_confirmation: 'It is password confirmation',
+      }),
+    });
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors[0].originalError).toBeInstanceOf(UserInputError);
+    }
+  });
+
+  it('성별 필드는 반드시 필요하다', async () => {
+    const input = UserFactory({
+      gender: undefined,
+    });
+    const { errors } = await graphql(registerMutation, {
+      input,
+    });
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0]).toBeInstanceOf(GraphQLError);
+    }
+  });
+
+  it('나이, 키, 몸무게, 체지방량, 골격근량, 휴대폰번호, 프로필 이미지 경로는 빈 값을 허용한다', async () => {
+    const nullableFields = [
+      'age',
+      'height',
+      'weight',
+      'fat',
+      'muscle',
+      'tel',
+      'profile_image_path',
+    ];
+
+    await Promise.all(
+      nullableFields.map(async field => {
+        const { errors } = await graphql(registerMutation, {
+          input: UserFactory({ [field]: undefined }),
+        });
+
+        expect(errors).toBeUndefined();
+      }),
+    );
+  });
+
+  it(`나이는 ${UserLimit.age.min}살 이상 ${UserLimit.age.max}살 이어야 한다`, async () => {
+    await Promise.all(
+      Object.entries(UserLimit.age).map(async ([key, value]) => {
+        const { errors } = await graphql(registerMutation, {
+          input: UserFactory({
+            age: value + (key === 'max' ? 1 : -1),
+          }),
+        });
+
+        expect(errors).not.toBeUndefined();
+        if (errors) {
+          expect(errors[0].originalError).toBeInstanceOf(
+            ArgumentValidationError,
+          );
+        }
+      }),
+    );
+  });
+
+  it(`키는 ${UserLimit.height.min}이상 ${UserLimit.height.max}이하 이어야 한다`, async () => {
+    await Promise.all(
+      Object.entries(UserLimit.height).map(async ([key, value]) => {
+        const { errors } = await graphql(registerMutation, {
+          input: UserFactory({
+            height: value + (key === 'max' ? 1 : -1),
+          }),
+        });
+
+        expect(errors).not.toBeUndefined();
+        if (errors) {
+          expect(errors[0].originalError).toBeInstanceOf(
+            ArgumentValidationError,
+          );
+        }
+      }),
+    );
+  });
+
+  it(`몸무게는 ${UserLimit.weight.min}이상 ${UserLimit.weight.max}이하 이어야 한다`, async () => {
+    await Promise.all(
+      Object.entries(UserLimit.weight).map(async ([key, value]) => {
+        const { errors } = await graphql(registerMutation, {
+          input: UserFactory({
+            weight: value + (key === 'max' ? 1 : -1),
+          }),
+        });
+
+        expect(errors).not.toBeUndefined();
+        if (errors) {
+          expect(errors[0].originalError).toBeInstanceOf(
+            ArgumentValidationError,
+          );
+        }
+      }),
+    );
+  });
+
+  it('휴대폰번호는 대한민국 휴대폰번호 형식이어야 한다', async () => {
+    const { errors } = await graphql(registerMutation, {
+      input: UserFactory({ tel: '1-206-123-4567' }),
+    });
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].originalError).toBeInstanceOf(ArgumentValidationError);
+    }
+  });
+
+  it('프로필 이미지 경로는 URL 형식이어야 한다', async () => {
+    const { errors } = await graphql(registerMutation, {
+      input: UserFactory({ profile_image_path: '/foo/bar/baz.jpg' }),
+    });
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].originalError).toBeInstanceOf(ArgumentValidationError);
+    }
+  });
+
+  it('데이터 베이스에 사용자 정보를 저장하기 전에 비밀번호를 해쉬화 한다', async () => {
+    const input = UserFactory();
+    const { data } = await graphql(registerMutation, {
+      input,
+    });
+
+    expect(
+      await bcrypt.compare(input.password, data?.register.password),
+    ).toBeTruthy();
+  });
+
+  it('유효성 검사에 통과되면 사용자 입력 데이터를 데이터 베이스에 추가한다', async () => {
+    const { data } = await graphql(registerMutation, {
+      input: UserFactory(),
+    });
+
+    expect(await UserModel.exists({ _id: data?.register._id })).toBeTruthy();
+  });
+
+  // TODO: #21
+  // it('사용자를 생성하고 이벤트를 실행한다', () => {});
+
+  // TODO: #7
+  // it('사용자를 정상적으로 등록한 후에 해당 사용자를 사용자 토큰과 함께 반환한다', () => {});
+});

--- a/tests/feature/registeration.test.ts
+++ b/tests/feature/registeration.test.ts
@@ -158,9 +158,9 @@ describe('회원가입을 할 수 있다', () => {
     }
   });
 
-  it('나이, 키, 몸무게, 체지방량, 골격근량, 휴대폰번호, 프로필 이미지 경로는 빈 값을 허용한다', async () => {
+  it('생년월일, 키, 몸무게, 체지방량, 골격근량, 휴대폰번호, 프로필 이미지 경로는 빈 값을 허용한다', async () => {
     const nullableFields = [
-      'age',
+      'birth',
       'height',
       'weight',
       'fat',
@@ -180,12 +180,15 @@ describe('회원가입을 할 수 있다', () => {
     );
   });
 
-  it(`나이는 ${UserLimit.age.min}살 이상 ${UserLimit.age.max}살 이어야 한다`, async () => {
+  it(`생년월일은 ${UserLimit.birth.minDate.getFullYear()}년 이상 ${UserLimit.birth.maxDate.getFullYear()}년 이하이어야 한다`, async () => {
     await Promise.all(
-      Object.entries(UserLimit.age).map(async ([key, value]) => {
+      Object.entries(UserLimit.birth).map(async ([key, value]) => {
+        const birth = new Date(value);
+        birth.setDate(birth.getDate() + (key === 'maxDate' ? 1 : -1));
+
         const { errors } = await graphql(registerMutation, {
           input: UserFactory({
-            age: value + (key === 'max' ? 1 : -1),
+            birth: birth.toISOString(),
           }),
         });
 

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,8 @@
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
+import faker from 'faker';
 
+faker.setLocale('ko');
 let mongoMemoryServer: MongoMemoryServer;
 
 beforeAll(async () => {

--- a/tests/unit/user.test.ts
+++ b/tests/unit/user.test.ts
@@ -1,0 +1,8 @@
+import { User } from '@src/models/User';
+import { Model } from '@src/models/Model';
+
+describe('사용자 모델', () => {
+  it('Model을 상속받고 있다', () => {
+    expect(Object.getPrototypeOf(User)).toEqual(Model);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,6 +606,21 @@
   resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
   integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
+"@mapbox/node-pre-gyp@^1.0.0":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.5.tgz#2a0b32fcb416fb3f2250fd24cb2a81421a4f5950"
+  integrity sha512-4srsKPXWlIxp5Vbqz5uLfBN+du2fJChBoYn/f2h991WLdk7jUvcSk/McVLSv/X+xQIPI8eGD5GjrnygdyHnhPA==
+  dependencies:
+    detect-libc "^1.0.3"
+    https-proxy-agent "^5.0.0"
+    make-dir "^3.1.0"
+    node-fetch "^2.6.1"
+    nopt "^5.0.0"
+    npmlog "^4.1.2"
+    rimraf "^3.0.2"
+    semver "^7.3.4"
+    tar "^6.1.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -782,6 +797,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bcrypt@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-5.0.0.tgz#a835afa2882d165aff5690893db314eaa98b9f20"
+  integrity sha512-agtcFKaruL8TmcvqbndlqHPSJgsolhf/qPWchFlgnW1gECTN/nKbFcoFnvKAQRFfKbh+BO6A3SWdJu9t+xF3Lw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/body-parser@*", "@types/body-parser@1.19.1":
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.1.tgz#0c0174c42a7d017b818303d4b5d969cb0b75929c"
@@ -892,6 +914,13 @@
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
+"@types/mongoose@^5.11.97":
+  version "5.11.97"
+  resolved "https://registry.yarnpkg.com/@types/mongoose/-/mongoose-5.11.97.tgz#80b0357f3de6807eb597262f52e49c3e13ee14d8"
+  integrity sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==
+  dependencies:
+    mongoose "*"
 
 "@types/node@*":
   version "16.9.1"
@@ -1142,6 +1171,16 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
+ansi-regex@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+  integrity sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
 ansi-regex@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
@@ -1291,6 +1330,19 @@ apollo-server@^3.3.0:
     apollo-server-express "^3.3.0"
     express "^4.17.1"
 
+aproba@^1.0.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
+  integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+are-we-there-yet@~1.1.2:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz#b15474a932adab4ff8a50d9adfa7e4e926f21146"
+  integrity sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^2.0.6"
+
 arg@^4.1.0:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
@@ -1407,6 +1459,14 @@ base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+bcrypt@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-5.0.1.tgz#f1a2c20f208e2ccdceea4433df0c8b2c54ecdf71"
+  integrity sha512-9BTgmrhZM2t1bNuDtrtIMVSmmxZBrJ71n8Wg+YgdjHuIWYF7SjjmCPZFB+/5i/o/PIeRpwVJR3P+NrpIItUjqw==
+  dependencies:
+    "@mapbox/node-pre-gyp" "^1.0.0"
+    node-addon-api "^3.1.0"
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -1618,6 +1678,11 @@ chokidar@^3.2.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -1667,6 +1732,11 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
+
+code-point-at@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
@@ -1735,6 +1805,11 @@ configstore@^5.0.1:
     unique-string "^2.0.0"
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
+
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+  integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -1896,6 +1971,11 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
+  integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
 denque@^1.4.1, denque@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/denque/-/denque-1.5.1.tgz#07f670e29c9a78f8faecb2566a1e2c11929c5cbf"
@@ -1910,6 +1990,11 @@ destroy@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
+
+detect-libc@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -2394,6 +2479,13 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
+fs-minipass@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
+  integrity sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+  dependencies:
+    minipass "^3.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2413,6 +2505,20 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  integrity sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
 
 gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
@@ -2560,6 +2666,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-unicode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+  integrity sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
 
 has-yarn@^2.1.0:
   version "2.1.0"
@@ -2752,6 +2863,13 @@ is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
+is-fullwidth-code-point@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
+  dependencies:
+    number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
@@ -3489,7 +3607,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-make-dir@^3.0.0, make-dir@^3.0.2:
+make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
@@ -3590,7 +3708,22 @@ minimist@^1.2.0, minimist@^1.2.5:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
-mkdirp@^1.0.4:
+minipass@^3.0.0:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.5.tgz#71f6251b0a33a49c01b3cf97ff77eda030dff732"
+  integrity sha512-+8NzxD82XQoNKNrl1d/FSi+X8wAEWR+sbYAfIvub4Nz0d22plFG72CEVVaufV8PNf4qSslFTD8VMOxNVhHCjTw==
+  dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
+    yallist "^4.0.0"
+
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -3658,7 +3791,7 @@ mongodb@^3.6.9:
   optionalDependencies:
     saslprep "^1.0.0"
 
-mongoose@^6.0.6:
+mongoose@*, mongoose@^6.0.6:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-6.0.6.tgz#d99d7c478b121e23c0035682da1b9b7640bff48b"
   integrity sha512-8lHgva/q5msZT16KOKDl+26Mh7uzTrmznup0p/TMqDCt7Y41voP7rZ0sTW/6tk2nsrmmMlJzzThJ8vexq7aQtQ==
@@ -3725,6 +3858,11 @@ new-find-package-json@^1.1.0:
     debug "^4.3.2"
     tslib "^2.3.0"
 
+node-addon-api@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
+  integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
+
 node-fetch@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.2.tgz#986996818b73785e47b1965cc34eb093a1d464d0"
@@ -3761,6 +3899,13 @@ nodemon@^2.0.12:
     undefsafe "^2.0.3"
     update-notifier "^4.1.0"
 
+nopt@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-5.0.0.tgz#530942bb58a512fccafe53fe210f13a25355dc88"
+  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+  dependencies:
+    abbrev "1"
+
 nopt@~1.0.10:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
@@ -3785,12 +3930,27 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
+npmlog@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
+
+number-is-nan@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
+  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
 nwsapi@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.0.tgz#204879a9e3d068ff2a55139c2c772780681a38b7"
   integrity sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
 
-object-assign@^4:
+object-assign@^4, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -4090,7 +4250,7 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-readable-stream@^2.3.5:
+readable-stream@^2.0.6, readable-stream@^2.3.5:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -4255,7 +4415,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
+semver@7.x, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -4301,6 +4461,11 @@ serve-static@1.14.1:
     parseurl "~1.3.3"
     send "0.17.1"
 
+set-blocking@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
 setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
@@ -4331,7 +4496,7 @@ sift@13.5.2:
   resolved "https://registry.yarnpkg.com/sift/-/sift-13.5.2.tgz#24a715e13c617b086166cd04917d204a591c9da6"
   integrity sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==
 
-signal-exit@^3.0.2, signal-exit@^3.0.3:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.4.tgz#366a4684d175b9cab2081e3681fda3747b6c51d7"
   integrity sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==
@@ -4416,6 +4581,23 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
+string-width@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
+  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
 string-width@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -4447,6 +4629,20 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
+
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
+  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+  dependencies:
+    ansi-regex "^2.0.0"
+
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  integrity sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+  dependencies:
+    ansi-regex "^3.0.0"
 
 strip-ansi@^5.1.0:
   version "5.2.0"
@@ -4543,6 +4739,18 @@ tar-stream@^2.1.4:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
+
+tar@^6.1.0:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 term-size@^2.1.0:
   version "2.2.1"
@@ -4927,6 +5135,13 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wide-align@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"
+  integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
+  dependencies:
+    string-width "^1.0.2 || 2"
 
 widest-line@^3.1.0:
   version "3.1.0"


### PR DESCRIPTION
### 작업 개요
#6 으로 인해 기본적인 틀만 구성되있던 `User`모델을 서비스 성격에 맞게 재정의합니다.

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `README.md` 파일에 test 스크립트
- 비밀번호 암호화는 [bcrypt](https://github.com/kelektiv/node.bcrypt.js) 사용
- `User` 모델에 **이름**, **이메일**, **닉네임**, **비밀번호**, **나이**, **성별**, **키**, **몸무게**, **지방량**, **골격근량**, **전화번호**, **프로필 이미지 경로** 필드 추가
  - `UserInput`, `UserFactoryInput`, `UserFactory`도 같이 추가
  - 필드에 대한 제한 사항(글자길이, 숫자 최소값 최대값 등)을 위한 `UserLimit`
  - 각각 필드들에 유효성 검사 추가
- 추후에 모든 모델들이 `_id`, `created_at`, `updated_at`은 반드시 사용할 것이라 생각하여 `Model` 클래스 생성 및 `User`모델 상속
- Query 및 Mutation 재정의
  - Query:
    - 모든 사용자를 불러오는 `users`
    - 특정 사용자만 불러오는 `user`
  - Mutation:
    - 회원가입(사용자 추가)하는 `register`
  - 테스트 추가
- 성별을 위한 `Gender` enum 타입 추가
- `faker` 한국어로 변경
- **나이** 대신 **생년월일**로 변경

### 생각해볼 문제
하나의 커밋에 너무 많은 업데이트가 있는 듯 하네유

resolve #17 