### PR TITLE
[refactor] 성격에 맞는 에러 생성

### DIFF
--- a/src/errors/AuthenticationError.ts
+++ b/src/errors/AuthenticationError.ts
@@ -1,0 +1,7 @@
+import { AuthenticationError as ApolloAuthenticationError } from 'apollo-server';
+
+export default class AuthenticationError extends ApolloAuthenticationError {
+  constructor() {
+    super('접근 불가! 이 작업을 수행하려면 승인이 필요합니다!');
+  }
+}

--- a/src/errors/ForbiddenError.ts
+++ b/src/errors/ForbiddenError.ts
@@ -1,0 +1,7 @@
+import { ForbiddenError as ApolloForbiddenError } from 'apollo-server';
+
+export default class ForbiddenError extends ApolloForbiddenError {
+  constructor() {
+    super('접근 불가! 이 작업에 대한 권한이 없습니다!');
+  }
+}

--- a/src/middlewares/AuthenticateMiddleware.ts
+++ b/src/middlewares/AuthenticateMiddleware.ts
@@ -1,12 +1,13 @@
-import { MiddlewareFn, UnauthorizedError } from 'type-graphql';
+import { MiddlewareFn } from 'type-graphql';
 import { Context } from '@src/context';
+import AuthenticationError from '@src/errors/AuthenticationError';
 
 export const AuthenticateMiddleware: MiddlewareFn<Context> = async (
   { context },
   next,
 ) => {
   if (!context || !context.user) {
-    throw new UnauthorizedError();
+    throw new AuthenticationError();
   }
 
   return await next();

--- a/src/middlewares/EnsureEmailIsVerifiedMiddleware.ts
+++ b/src/middlewares/EnsureEmailIsVerifiedMiddleware.ts
@@ -1,6 +1,7 @@
-import { ForbiddenError, MiddlewareFn } from 'type-graphql';
+import { MiddlewareFn } from 'type-graphql';
 import { Context } from '@src/context';
 import { UserModel } from '@src/models/User';
+import ForbiddenError from '@src/errors/ForbiddenError';
 
 export const EnsureEmailIsVerifiedMiddleware: MiddlewareFn<Context> = async (
   { context },

--- a/src/middlewares/GuestMiddleware.ts
+++ b/src/middlewares/GuestMiddleware.ts
@@ -1,5 +1,6 @@
-import { ForbiddenError, MiddlewareFn } from 'type-graphql';
+import { MiddlewareFn } from 'type-graphql';
 import { Context } from '@src/context';
+import ForbiddenError from '@src/errors/ForbiddenError';
 
 export const GuestMiddleware: MiddlewareFn<Context> = async (
   { context },

--- a/tests/feature/get-users.test.ts
+++ b/tests/feature/get-users.test.ts
@@ -1,8 +1,8 @@
 import { UserModel } from '@src/models/User';
 import { UserFactory } from '@src/factories/UserFactory';
-import { UnauthorizedError } from 'type-graphql';
 import { graphql } from '@tests/graphql';
 import { signIn } from '@tests/helpers';
+import AuthenticationError from '@src/errors/AuthenticationError';
 
 describe('사용자 모델', () => {
   it('모든 사용자를 조회할 수 있다', async () => {
@@ -39,7 +39,7 @@ describe('사용자 모델', () => {
     expect(errors).not.toBeUndefined();
     if (errors) {
       expect(errors.length).toEqual(1);
-      expect(errors[0].originalError).toBeInstanceOf(UnauthorizedError);
+      expect(errors[0].originalError).toBeInstanceOf(AuthenticationError);
     }
   });
 

--- a/tests/feature/logination.test.ts
+++ b/tests/feature/logination.test.ts
@@ -1,12 +1,15 @@
 import { signIn } from '@tests/helpers';
 import { graphql } from '@tests/graphql';
-import { ArgumentValidationError, ForbiddenError } from 'type-graphql';
+import { ArgumentValidationError } from 'type-graphql';
 import { UserFactory } from '@src/factories/UserFactory';
 import { UserLimit } from '@src/limits/UserLimit';
 import { UserFactoryInput } from '@src/factories/types/UserFactoryInput';
 import { LoginInput } from '@src/resolvers/types/LoginInput';
 import { UserInputError } from 'apollo-server';
 import { UserModel } from '@src/models/User';
+import ForbiddenError from '@src/errors/ForbiddenError';
+import { mongoose } from '@typegoose/typegoose';
+import DocumentNotFoundError = mongoose.Error.DocumentNotFoundError;
 
 describe('사용자 로그인', () => {
   const loginMutation = `mutation login($input: LoginInput!) { login(input: $input) { token, refresh_token } }`;
@@ -89,10 +92,7 @@ describe('사용자 로그인', () => {
     expect(errors).not.toBeUndefined();
     if (errors) {
       expect(errors.length).toEqual(1);
-      expect(errors[0].originalError).toBeInstanceOf(UserInputError);
-      expect(errors[0].message).toEqual(
-        `사용자를 찾을 수 없습니다. email: ${email}`,
-      );
+      expect(errors[0].originalError).toBeInstanceOf(DocumentNotFoundError);
     }
   });
 

--- a/tests/feature/registeration.test.ts
+++ b/tests/feature/registeration.test.ts
@@ -3,10 +3,11 @@ import { graphql } from '@tests/graphql';
 import { UserLimit } from '@src/limits/UserLimit';
 import { GraphQLError } from 'graphql';
 import { UserModel } from '@src/models/User';
-import { ArgumentValidationError, ForbiddenError } from 'type-graphql';
+import { ArgumentValidationError } from 'type-graphql';
 import { UserInputError } from 'apollo-server';
 import bcrypt from 'bcrypt';
 import { signIn } from '@tests/helpers';
+import ForbiddenError from '@src/errors/ForbiddenError';
 
 describe('회원가입을 할 수 있다', () => {
   const registerMutation = `mutation register($input: UserInput!) { register(input: $input) { _id, password } }`;

--- a/tests/feature/token-refreshation.test.ts
+++ b/tests/feature/token-refreshation.test.ts
@@ -1,9 +1,11 @@
 import { signIn } from '@tests/helpers';
 import { graphql } from '@tests/graphql';
-import { ForbiddenError } from 'type-graphql';
 import { UserInputError } from 'apollo-server';
 import randToken from 'rand-token';
 import { UserModel } from '@src/models/User';
+import ForbiddenError from '@src/errors/ForbiddenError';
+import { mongoose } from '@typegoose/typegoose';
+import DocumentNotFoundError = mongoose.Error.DocumentNotFoundError;
 
 describe('JWT 토큰 갱신', () => {
   const refreshTokenMutation = `mutation refreshToken($refresh_token: String!) { refreshToken(refresh_token: $refresh_token) { token, refresh_token } }`;
@@ -47,10 +49,7 @@ describe('JWT 토큰 갱신', () => {
     expect(errors).not.toBeUndefined();
     if (errors) {
       expect(errors.length).toEqual(1);
-      expect(errors[0].originalError).toBeInstanceOf(Error);
-      expect(errors[0].message).toEqual(
-        `해당 refresh_token의 사용자를 찾을 수 없습니다. refresh_token: ${refresh_token}`,
-      );
+      expect(errors[0].originalError).toBeInstanceOf(DocumentNotFoundError);
     }
   });
 

--- a/tests/feature/verification.test.ts
+++ b/tests/feature/verification.test.ts
@@ -1,10 +1,11 @@
 import { graphql } from '@tests/graphql';
-import { ArgumentValidationError, UnauthorizedError } from 'type-graphql';
+import { ArgumentValidationError } from 'type-graphql';
 import { signIn } from '@tests/helpers';
 import { UserModel } from '@src/models/User';
 import { VerifyInput } from '@src/resolvers/types/VerifyInput';
 import { UserFactory } from '@src/factories/UserFactory';
 import randToken from 'rand-token';
+import AuthenticationError from '@src/errors/AuthenticationError';
 
 describe('이메일 인증', () => {
   describe('인증 메일 전송', () => {
@@ -16,7 +17,7 @@ describe('이메일 인증', () => {
       expect(errors).not.toBeUndefined();
       if (errors) {
         expect(errors.length).toEqual(1);
-        expect(errors[0].originalError).toBeInstanceOf(UnauthorizedError);
+        expect(errors[0].originalError).toBeInstanceOf(AuthenticationError);
       }
     });
 


### PR DESCRIPTION
### 작업 개요
에러를 발생시킬 때 각 성격에 맞는 에러를 반환하기 위해 에러 클래스 생성

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- `apollo-server`의 `AuthenticationError`를 상속받는 `AuthenticationError` 클래스 생성(에러 메세지 통일)
- `apollo-server`의 `ForbiddenError`를 상속받는 `ForbiddenError` 클래스 생성(에러 메세지 통일)
- `type-graphql`의 `UnauthorizedError` 사용하던 것을 `AuthenticationError`로 변경
- `type-graphql`의 `ForbiddenError` 사용하던 것을 이번에 만든 `ForbiddenError`로 변경
- **`UserResolver`에서 사용자를 찾고, 사용자가 없으면 에러를 발생시키던 것을 mongoose 쿼리의 `orFail` 메서드를 사용함**

### 생각해볼 문제
소셜 로그인했던 사용자가 네이티브 로그인을 요청했을 때
네이티브 로그인 한 사용자의 비밀번호가 틀렸을 때
같은 인스턴스의 에러를 반환하고 있다. 클라이언트쪽에서 구분하기 어려울 듯

resolve #31 
