### PR TITLE
[refactor] 모델들 재정의

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,6 @@ module.exports = {
   plugins: ['@typescript-eslint'],
   rules: {
     'prettier/prettier': 'error',
+    '@typescript-eslint/no-empty-interface': 'off',
   },
 };

--- a/src/models/Training.ts
+++ b/src/models/Training.ts
@@ -1,16 +1,20 @@
 import { Model } from '@src/models/Model';
 import { Field, Int, ObjectType } from 'type-graphql';
-import { prop } from '@typegoose/typegoose';
+import { getModelForClass, prop } from '@typegoose/typegoose';
 import { TrainingType } from '@src/types/enums';
+import {
+  TrainingMethods,
+  TrainingQueryHelpers,
+} from '@src/models/types/Training';
 
 @ObjectType({ implements: Model, description: '운동종목 모델' })
-export class Training extends Model {
+export class Training extends Model implements TrainingMethods {
   @Field(() => String, { description: '이름' })
   @prop({ type: String, required: true })
   name: string;
 
   @Field(() => TrainingType, { description: '종류' })
-  @prop({ type: TrainingType, required: true })
+  @prop({ enum: TrainingType, required: true })
   type: TrainingType;
 
   @Field(() => String, { description: '설명', nullable: true })
@@ -18,7 +22,7 @@ export class Training extends Model {
   description?: string;
 
   @Field(() => Int, { description: '선호도', defaultValue: 1 })
-  @prop({ type: Int, default: 1 })
+  @prop({ type: Number, default: 1 })
   preference?: number;
 
   @Field(() => String, { description: '썸네일 경로', nullable: true })
@@ -29,3 +33,8 @@ export class Training extends Model {
   @prop({ type: String })
   video_path?: string;
 }
+
+export const TrainingModel = getModelForClass<
+  typeof Training,
+  TrainingQueryHelpers
+>(Training);

--- a/src/models/types/Training.ts
+++ b/src/models/types/Training.ts
@@ -1,0 +1,3 @@
+export interface TrainingMethods {}
+
+export interface TrainingQueryHelpers {}

--- a/src/models/types/User.ts
+++ b/src/models/types/User.ts
@@ -1,0 +1,9 @@
+import { DocumentType } from '@typegoose/typegoose';
+import { LoginResponse } from '@src/resolvers/types/LoginResponse';
+import { User } from '@src/models/User';
+
+export interface UserMethods {
+  getJWTToken: (this: DocumentType<User>) => Promise<LoginResponse>;
+}
+
+export interface UserQueryHelpers {}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,9 +3,10 @@ import { UserFactory } from '@src/factories/UserFactory';
 import { UserFactoryInput } from '@src/factories/types/UserFactoryInput';
 import { sign } from '@src/plugins/jwt';
 import { EnforceDocument } from 'mongoose';
+import { UserMethods } from '@src/models/types/User';
 
 export async function signIn(input?: UserFactoryInput): Promise<{
-  user: EnforceDocument<User, unknown>;
+  user: EnforceDocument<User, UserMethods>;
   token: string;
   refresh_token: string;
 }> {

--- a/tests/unit/user.test.ts
+++ b/tests/unit/user.test.ts
@@ -1,8 +1,20 @@
-import { User } from '@src/models/User';
+import { User, UserModel } from '@src/models/User';
 import { Model } from '@src/models/Model';
+import { UserFactory } from '@src/factories/UserFactory';
 
 describe('사용자 모델', () => {
   it('Model을 상속받고 있다', () => {
     expect(Object.getPrototypeOf(User)).toEqual(Model);
+  });
+
+  it('refresh_token을 업데이트하고 JWT 토큰을 반환하는 getJWTToken 메서드를 가지고 있다', async () => {
+    const user = await UserModel.create(UserFactory());
+    const beforeRefreshToken = user.refresh_token;
+
+    expect(user).toHaveProperty('getJWTToken');
+    const { token, refresh_token } = await user.getJWTToken();
+
+    expect(beforeRefreshToken === refresh_token).toBeFalsy();
+    expect(token).not.toBeUndefined();
   });
 });


### PR DESCRIPTION
### 작업 개요
typegoose 쿼리 후 반환하는 `EnforceDocument`에 메서드와 쿼리헬퍼를 타입힌팅한다

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- 모든 모델들에게 메서드와 쿼리헬퍼 인터페이스를 상속
  - 모든 모델이 메서드와 쿼리헬퍼 인터페이스의 값이 있는 것이 아니기 때문에 `eslint` `@typescript-eslint/no-empty-interface` 규칙을 수정
- 기존에 만들어져있던 `Training` 모델에 `typegoose` 모델 생성 선언이 없었던 것 수정
- `User` 모델에 재사용성이 다분한 JWT 토큰 반환 기능을 메서드로 뺌
  - 테스트 추가

### 생각해볼 문제


resolve #40 

