### PR TITLE
[refactor] apollo context에 사용자의 모든 정보 저장

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "apollo-server": "^3.3.0",
     "bcrypt": "^5.0.1",
     "class-validator": "^0.13.1",
+    "express": "^4.17.1",
     "graphql": "^15.5.3",
     "jsonwebtoken": "^8.5.1",
     "mailgen": "^2.0.15",

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,18 +1,25 @@
 import { verify } from '@src/plugins/jwt';
 import { ContextFunction } from 'apollo-server-core/src/types';
 import { ExpressContext } from 'apollo-server-express/src/ApolloServer';
-import { User } from '@src/models/User';
+import { User, UserModel } from '@src/models/User';
+import { EnforceDocument } from 'mongoose';
+import { UserMethods } from '@src/models/types/User';
 
 export interface Context {
-  user?: Partial<User>;
+  user?: EnforceDocument<User, UserMethods>;
 }
 
-export const context: ContextFunction<ExpressContext, Context> = ({
+export const context: ContextFunction<ExpressContext, Context> = async ({
   req: {
     headers: { authorization },
   },
-}) => ({
-  user: authorization
+}) => {
+  const filter = authorization
     ? verify(authorization.replace('Bearer ', ''))
-    : undefined,
-});
+    : undefined;
+  const user = filter
+    ? (await UserModel.findOne(filter).exec()) || undefined
+    : undefined;
+
+  return { user };
+};

--- a/tests/graphql.ts
+++ b/tests/graphql.ts
@@ -2,7 +2,8 @@ import { graphql as _graphql } from 'graphql';
 import { ExecutionResult } from 'graphql/execution/execute';
 import { Maybe } from 'graphql/jsutils/Maybe';
 import { schema } from '@src/schema';
-import { verify } from '@src/plugins/jwt';
+import { context } from '@src/context';
+import { Request, Response } from 'express';
 
 export const graphql = async (
   source: string,
@@ -13,7 +14,10 @@ export const graphql = async (
     schema: await schema,
     source,
     variableValues,
-    contextValue: {
-      user: token ? verify(token) : undefined,
-    },
+    contextValue: await context({
+      req: {
+        headers: { authorization: token ? `Bearer ${token}` : undefined },
+      } as Request,
+      res: {} as Response,
+    }),
   });


### PR DESCRIPTION
### 작업 개요
이전엔 서버 `context`에 사용자의 `_id`만 저장되고 있었는데 모든 사용자 정보를 저장

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- 테스트 시 `context`에 필요한 mock 요청, 응답을 위해 `express` 설치
- `context`의 `user`키 타입 변경 및 리턴 값 변경
- `context`의 `user._id`를 사용해 사용자 정보를 가져오던 모든 코드 리팩토링

resolve #39 

