### PR TITLE
[style] enum 값 대문자로 변경

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,4 +1,3 @@
-import 'reflect-metadata';
 import { connect } from 'mongoose';
 import { ApolloServer } from 'apollo-server';
 import { schema } from '@src/schema';

--- a/src/factories/UserFactory.ts
+++ b/src/factories/UserFactory.ts
@@ -2,6 +2,7 @@ import faker from 'faker';
 import { UserFactoryInput } from '@src/factories/types/UserFactoryInput';
 import { UserInput } from '@src/resolvers/types/UserInput';
 import { UserLimit } from '@src/limits/UserLimit';
+import { Gender } from '@src/types/enums';
 
 export const UserFactory: (input?: UserFactoryInput) => UserInput = input => {
   const password = faker.random.words(4);
@@ -15,7 +16,7 @@ export const UserFactory: (input?: UserFactoryInput) => UserInput = input => {
       nickname: faker.unique(faker.name.firstName),
       password,
       password_confirmation: password,
-      gender: faker.random.arrayElement(['male', 'female']),
+      gender: faker.random.arrayElement([Gender.MALE, Gender.FEMALE]),
       birth: faker.date
         .between(UserLimit.birth.minDate, UserLimit.birth.maxDate)
         .toISOString(),

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,11 +1,9 @@
-import { buildSchema, registerEnumType } from 'type-graphql';
+import { buildSchema } from 'type-graphql';
 import { TypegooseMiddleware } from '@src/middlewares/TypegooseMiddleware';
 import { ObjectId } from 'mongodb';
 import { ObjectIdScalar } from '@src/scalars/ObjectIdScalar';
 import { GraphQLSchema } from 'graphql';
-import { Gender } from '@src/types/enums';
-
-registerEnumType(Gender, { name: 'Gender', description: '성별' });
+import '@src/types/enums';
 
 export const schema: Promise<GraphQLSchema> = buildSchema({
   resolvers: [__dirname + '/**/resolvers/*Resolver.{ts,js}'],

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,15 +1,23 @@
+import 'reflect-metadata';
+import { registerEnumType } from 'type-graphql';
+
 export enum Gender {
-  male = 'male',
-  female = 'female',
+  MALE = 'MALE',
+  FEMALE = 'FEMALE',
 }
+registerEnumType(Gender, { name: 'Gender', description: '성별' });
 
 export enum TrainingType {
-  lower = 'lower', // 하체
-  chest = 'chest', // 가슴
-  back = 'back', // 등
-  shoulder = 'shoulder', // 어꺠
-  arm = 'arm', // 팔
-  abdominal = 'abdominal', // 복근
-  cardiovascular = 'cardiovascular', // 유산소
-  etc = 'etc', // 기타
+  LOWER = 'LOWER', // 하체
+  CHEST = 'CHEST', // 가슴
+  BACK = 'BACK', // 등
+  SHOULDER = 'SHOULDER', // 어꺠
+  ARM = 'ARM', // 팔
+  ABDOMINAL = 'ABDOMINAL', // 복근
+  CARDIOVASCULAR = 'CARDIOVASCULAR', // 유산소
+  ETC = 'ETC', // 기타
 }
+registerEnumType(TrainingType, {
+  name: 'TrainingType',
+  description: '운동종류',
+});


### PR DESCRIPTION
### 작업 개요
`enum` 값들을 모두 대문자로 변경

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- `type-graphql`의 `enum`을 등록하는 `registerEnumType`을 `enum.ts` 파일로 이동
  -  `registerEnumType`을 사용하는 파일에 `reflect-metadata`를 임포트해야해서 이동
- 모든 `enum` 값 대문자로 변경

resolve #43 

