### PR TITLE
[feat] 운동종목 추가

### DIFF
--- a/src/errors/ForbiddenError.ts
+++ b/src/errors/ForbiddenError.ts
@@ -1,7 +1,0 @@
-import { ForbiddenError as ApolloForbiddenError } from 'apollo-server';
-
-export default class ForbiddenError extends ApolloForbiddenError {
-  constructor() {
-    super('접근 불가! 이 작업에 대한 권한이 없습니다!');
-  }
-}

--- a/src/factories/TrainingFactory.ts
+++ b/src/factories/TrainingFactory.ts
@@ -1,0 +1,31 @@
+import faker from 'faker';
+import { TrainingType } from '@src/types/enums';
+import { TrainingFactoryInput } from '@src/factories/types/TrainingFactoryInput';
+import { TrainingInput } from '@src/resolvers/types/TrainingInput';
+import { TrainingLimit } from '@src/limits/TrainingLimit';
+
+export const TrainingFactory: (input?: TrainingFactoryInput) => TrainingInput =
+  input =>
+    Object.assign(
+      {
+        name: faker.unique(faker.name.lastName),
+        type: faker.random.arrayElement([
+          TrainingType.LOWER,
+          TrainingType.CHEST,
+          TrainingType.BACK,
+          TrainingType.SHOULDER,
+          TrainingType.ARM,
+          TrainingType.ABDOMINAL,
+          TrainingType.CARDIOVASCULAR,
+          TrainingType.ETC,
+        ]),
+        description: faker.random.words(),
+        preference: faker.datatype.number({
+          min: TrainingLimit.preference.min,
+          max: TrainingLimit.preference.max,
+        }),
+        thumbnail_path: faker.image.imageUrl(64, 64),
+        video_path: faker.image.imageUrl(64, 64),
+      },
+      input,
+    ) as TrainingInput;

--- a/src/factories/types/TrainingFactoryInput.ts
+++ b/src/factories/types/TrainingFactoryInput.ts
@@ -1,0 +1,47 @@
+import { Field, InputType, Int } from 'type-graphql';
+import { Training } from '@src/models/Training';
+import {
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Max,
+  Min,
+} from 'class-validator';
+import { TrainingType } from '@src/types/enums';
+
+@InputType({ description: '운동종목 추가 입력 객체' })
+export class TrainingFactoryInput implements Partial<Training> {
+  @Field(() => String, { description: '이름', nullable: true })
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @Field(() => TrainingType, { description: '종류', nullable: true })
+  @IsOptional()
+  @IsEnum(TrainingType)
+  type?: TrainingType;
+
+  @Field(() => String, { description: '설명', nullable: true })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @Field(() => Int, { description: '선호도', defaultValue: 1 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  preference?: number;
+
+  @Field(() => String, { description: '썸네일 경로', nullable: true })
+  @IsOptional()
+  @IsUrl()
+  thumbnail_path?: string;
+
+  @Field(() => String, { description: '운동영상 경로', nullable: true })
+  @IsOptional()
+  @IsUrl()
+  video_path?: string;
+}

--- a/src/limits/TrainingLimit.ts
+++ b/src/limits/TrainingLimit.ts
@@ -1,0 +1,6 @@
+export const TrainingLimit = {
+  preference: {
+    min: 1,
+    max: 10,
+  },
+};

--- a/src/middlewares/GuestMiddleware.ts
+++ b/src/middlewares/GuestMiddleware.ts
@@ -1,6 +1,5 @@
-import { MiddlewareFn } from 'type-graphql';
+import { ForbiddenError, MiddlewareFn } from 'type-graphql';
 import { Context } from '@src/context';
-import ForbiddenError from '@src/errors/ForbiddenError';
 
 export const GuestMiddleware: MiddlewareFn<Context> = async (
   { context },

--- a/src/models/Training.ts
+++ b/src/models/Training.ts
@@ -10,7 +10,7 @@ import {
 @ObjectType({ implements: Model, description: '운동종목 모델' })
 export class Training extends Model implements TrainingMethods {
   @Field(() => String, { description: '이름' })
-  @prop({ type: String, required: true })
+  @prop({ type: String, required: true, unique: true })
   name: string;
 
   @Field(() => TrainingType, { description: '종류' })

--- a/src/resolvers/TrainingResolver.ts
+++ b/src/resolvers/TrainingResolver.ts
@@ -1,0 +1,16 @@
+import { Arg, Authorized, Mutation, Resolver } from 'type-graphql';
+import { Training, TrainingModel } from '@src/models/Training';
+import { TrainingInput } from '@src/resolvers/types/TrainingInput';
+import { EnforceDocument } from 'mongoose';
+import { TrainingMethods } from '@src/models/types/Training';
+
+@Resolver(() => Training)
+export class TrainingResolver {
+  @Mutation(() => Training, { description: '운동종목 추가' })
+  @Authorized('ADMIN')
+  async createTraining(
+    @Arg('input') input: TrainingInput,
+  ): Promise<EnforceDocument<Training, TrainingMethods>> {
+    return TrainingModel.create(input);
+  }
+}

--- a/src/resolvers/UserResolver.ts
+++ b/src/resolvers/UserResolver.ts
@@ -21,17 +21,21 @@ import { VerifyInput } from '@src/resolvers/types/VerifyInput';
 import { UserLimit } from '@src/limits/UserLimit';
 import AuthenticationError from '@src/errors/AuthenticationError';
 import { Role } from '@src/types/enums';
+import { EnforceDocument } from 'mongoose';
+import { UserMethods } from '@src/models/types/User';
 
 @Resolver(() => User)
 export class UserResolver {
   @Query(() => [User], { description: '모든 사용자 조회' })
-  async users(): Promise<User[]> {
+  async users(): Promise<EnforceDocument<User, UserMethods>[]> {
     return UserModel.find({});
   }
 
   @Query(() => User, { description: '특정 사용자 조회' })
   @UseMiddleware(AuthenticateMiddleware)
-  async me(@Ctx() { user }: Context): Promise<User> {
+  async me(
+    @Ctx() { user }: Context,
+  ): Promise<EnforceDocument<User, UserMethods>> {
     if (!user) {
       throw new AuthenticationError();
     }
@@ -41,7 +45,9 @@ export class UserResolver {
 
   @Mutation(() => User, { description: '사용자 생성' })
   @UseMiddleware(GuestMiddleware)
-  async register(@Arg('input') input: UserInput): Promise<User> {
+  async register(
+    @Arg('input') input: UserInput,
+  ): Promise<EnforceDocument<User, UserMethods>> {
     if (input.password !== input.password_confirmation) {
       throw new UserInputError('비밀번호와 비밀번호 확인 값이 다릅니다');
     }

--- a/src/resolvers/types/TrainingInput.ts
+++ b/src/resolvers/types/TrainingInput.ts
@@ -1,0 +1,48 @@
+import { Field, InputType, Int } from 'type-graphql';
+import { Training } from '@src/models/Training';
+import {
+  IsDefined,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Max,
+  Min,
+} from 'class-validator';
+import { TrainingType } from '@src/types/enums';
+
+@InputType({ description: '운동종목 추가 입력 객체' })
+export class TrainingInput implements Partial<Training> {
+  @Field(() => String, { description: '이름' })
+  @IsDefined()
+  @IsString()
+  name: string;
+
+  @Field(() => TrainingType, { description: '종류' })
+  @IsDefined()
+  @IsEnum(TrainingType)
+  type: TrainingType;
+
+  @Field(() => String, { description: '설명', nullable: true })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @Field(() => Int, { description: '선호도', defaultValue: 1 })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  preference?: number;
+
+  @Field(() => String, { description: '썸네일 경로', nullable: true })
+  @IsOptional()
+  @IsUrl()
+  thumbnail_path?: string;
+
+  @Field(() => String, { description: '운동영상 경로', nullable: true })
+  @IsOptional()
+  @IsUrl()
+  video_path?: string;
+}

--- a/tests/feature/create-training.test.ts
+++ b/tests/feature/create-training.test.ts
@@ -1,0 +1,185 @@
+import { graphql } from '@tests/graphql';
+import { TrainingFactory } from '@src/factories/TrainingFactory';
+import { ArgumentValidationError, ForbiddenError } from 'type-graphql';
+import { signIn } from '@tests/helpers';
+import { Role } from '@src/types/enums';
+import { mongoose } from '@typegoose/typegoose';
+import ValidationError = mongoose.Error.ValidationError;
+import { TrainingModel } from '@src/models/Training';
+import { GraphQLError } from 'graphql';
+import { TrainingLimit } from '@src/limits/TrainingLimit';
+
+describe('운동종목 추가', () => {
+  const createTrainingMutation = `mutation createTraining($input: TrainingInput!) { createTraining(input: $input) { _id } }`;
+
+  it('로그인 하지 않으면 추가할 수 없다', async () => {
+    const { errors } = await graphql(createTrainingMutation, {
+      input: TrainingFactory(),
+    });
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].originalError).toBeInstanceOf(ForbiddenError);
+    }
+  });
+
+  it('관리자 권한이 없으면 추가할 수 없다', async () => {
+    const { token } = await signIn();
+    const { errors } = await graphql(
+      createTrainingMutation,
+      {
+        input: TrainingFactory(),
+      },
+      token,
+    );
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].originalError).toBeInstanceOf(ForbiddenError);
+    }
+  });
+
+  it('관리자는 추가할 수 있다', async () => {
+    const { token } = await signIn(undefined, [Role.ADMIN]);
+    const { data, errors } = await graphql(
+      createTrainingMutation,
+      {
+        input: TrainingFactory(),
+      },
+      token,
+    );
+
+    expect(errors).toBeUndefined();
+    expect(data?.createTraining).toHaveProperty('_id');
+  });
+
+  it('이름 필드는 반드시 필요하다', async () => {
+    const { token } = await signIn(undefined, [Role.ADMIN]);
+    const { errors } = await graphql(
+      createTrainingMutation,
+      {
+        input: TrainingFactory({ name: '' }),
+      },
+      token,
+    );
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].originalError).toBeInstanceOf(ValidationError);
+    }
+  });
+
+  it('이미 등록된 이름을 사용할 수 없다', async () => {
+    const { token } = await signIn(undefined, [Role.ADMIN]);
+    const name = '바벨 백스쿼트';
+    await TrainingModel.create(TrainingFactory({ name }));
+    const { errors } = await graphql(
+      createTrainingMutation,
+      {
+        input: TrainingFactory({ name }),
+      },
+      token,
+    );
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].message).toContain('E11000 duplicate key error dup key');
+    }
+  });
+
+  it('종류 필드는 반드시 필요하다', async () => {
+    const { token } = await signIn(undefined, [Role.ADMIN]);
+    const input = TrainingFactory({
+      type: undefined,
+    });
+    const { errors } = await graphql(
+      createTrainingMutation,
+      {
+        input,
+      },
+      token,
+    );
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0]).toBeInstanceOf(GraphQLError);
+    }
+  });
+
+  it('설명, 선호도, 썸네일경로, 영상경로는 빈값을 허용한다', async () => {
+    const { token } = await signIn(undefined, [Role.ADMIN]);
+
+    await Promise.all(
+      ['description', 'preference', 'thumbnail_path', 'video_path'].map(
+        async field => {
+          const { errors } = await graphql(
+            createTrainingMutation,
+            {
+              input: TrainingFactory({ [field]: undefined }),
+            },
+            token,
+          );
+
+          expect(errors).toBeUndefined();
+        },
+      ),
+    );
+  });
+
+  it(`선호도는 ${TrainingLimit.preference.min}이상 ${TrainingLimit.preference.max}이하 이어야 한다`, async () => {
+    const { token } = await signIn(undefined, [Role.ADMIN]);
+
+    await Promise.all(
+      Object.entries(TrainingLimit.preference).map(async ([key, value]) => {
+        const { errors } = await graphql(
+          createTrainingMutation,
+          {
+            input: TrainingFactory({
+              preference: value + (key === 'max' ? 1 : -1),
+            }),
+          },
+          token,
+        );
+
+        expect(errors).not.toBeUndefined();
+        if (errors) {
+          expect(errors[0].originalError).toBeInstanceOf(
+            ArgumentValidationError,
+          );
+        }
+      }),
+    );
+  });
+
+  it('썸네일경로와 영상경로는 URL 형식이어야 한다', async () => {
+    const { token } = await signIn(undefined, [Role.ADMIN]);
+
+    await Promise.all(
+      ['thumbnail_path', 'video_path'].map(async field => {
+        const { errors } = await graphql(
+          createTrainingMutation,
+          {
+            input: TrainingFactory({ [field]: '/foo/bar/baz.jpg' }),
+          },
+          token,
+        );
+
+        expect(errors).not.toBeUndefined();
+        if (errors) {
+          expect(errors.length).toEqual(1);
+          expect(errors[0].originalError).toBeInstanceOf(
+            ArgumentValidationError,
+          );
+        }
+      }),
+    );
+  });
+
+  // TODO: #21
+  // it('종목을 생성하고 이벤트를 실행한다', () => {});
+});

--- a/tests/feature/logination.test.ts
+++ b/tests/feature/logination.test.ts
@@ -1,13 +1,12 @@
 import { signIn } from '@tests/helpers';
 import { graphql } from '@tests/graphql';
-import { ArgumentValidationError } from 'type-graphql';
+import { ArgumentValidationError, ForbiddenError } from 'type-graphql';
 import { UserFactory } from '@src/factories/UserFactory';
 import { UserLimit } from '@src/limits/UserLimit';
 import { UserFactoryInput } from '@src/factories/types/UserFactoryInput';
 import { LoginInput } from '@src/resolvers/types/LoginInput';
 import { UserInputError } from 'apollo-server';
 import { UserModel } from '@src/models/User';
-import ForbiddenError from '@src/errors/ForbiddenError';
 import { mongoose } from '@typegoose/typegoose';
 import DocumentNotFoundError = mongoose.Error.DocumentNotFoundError;
 

--- a/tests/feature/registeration.test.ts
+++ b/tests/feature/registeration.test.ts
@@ -3,11 +3,10 @@ import { graphql } from '@tests/graphql';
 import { UserLimit } from '@src/limits/UserLimit';
 import { GraphQLError } from 'graphql';
 import { UserModel } from '@src/models/User';
-import { ArgumentValidationError } from 'type-graphql';
+import { ArgumentValidationError, ForbiddenError } from 'type-graphql';
 import { UserInputError } from 'apollo-server';
 import bcrypt from 'bcrypt';
 import { signIn } from '@tests/helpers';
-import ForbiddenError from '@src/errors/ForbiddenError';
 
 describe('회원가입을 할 수 있다', () => {
   const registerMutation = `mutation register($input: UserInput!) { register(input: $input) { _id, password } }`;
@@ -174,10 +173,8 @@ describe('회원가입을 할 수 있다', () => {
   });
 
   it('생년월일, 휴대폰번호, 프로필 이미지 경로는 빈 값을 허용한다', async () => {
-    const nullableFields = ['birth', 'tel', 'profile_image_path'];
-
     await Promise.all(
-      nullableFields.map(async field => {
+      ['birth', 'tel', 'profile_image_path'].map(async field => {
         const { errors } = await graphql(registerMutation, {
           input: UserFactory({ [field]: undefined }),
         });

--- a/tests/feature/token-refreshation.test.ts
+++ b/tests/feature/token-refreshation.test.ts
@@ -3,9 +3,9 @@ import { graphql } from '@tests/graphql';
 import { UserInputError } from 'apollo-server';
 import randToken from 'rand-token';
 import { UserModel } from '@src/models/User';
-import ForbiddenError from '@src/errors/ForbiddenError';
 import { mongoose } from '@typegoose/typegoose';
 import DocumentNotFoundError = mongoose.Error.DocumentNotFoundError;
+import { ForbiddenError } from 'type-graphql';
 
 describe('JWT 토큰 갱신', () => {
   const refreshTokenMutation = `mutation refreshToken($refresh_token: String!) { refreshToken(refresh_token: $refresh_token) { token, refresh_token } }`;

--- a/tests/feature/verification.test.ts
+++ b/tests/feature/verification.test.ts
@@ -23,8 +23,7 @@ describe('이메일 인증', () => {
     });
 
     it('이메일이 이미 인증된 사용자는 요청할 수 없다', async () => {
-      const { user, token } = await signIn();
-      await user.updateOne({ $push: { roles: Role.VERIFIED } });
+      const { token } = await signIn(undefined, [Role.VERIFIED]);
       const { errors } = await graphql(
         sendVerifyEmailMutation,
         undefined,

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -4,13 +4,19 @@ import { UserFactoryInput } from '@src/factories/types/UserFactoryInput';
 import { sign } from '@src/plugins/jwt';
 import { EnforceDocument } from 'mongoose';
 import { UserMethods } from '@src/models/types/User';
+import { Role } from '@src/types/enums';
 
-export async function signIn(input?: UserFactoryInput): Promise<{
+export async function signIn(
+  input?: UserFactoryInput,
+  roles?: Role[],
+): Promise<{
   user: EnforceDocument<User, UserMethods>;
   token: string;
   refresh_token: string;
 }> {
-  const user = await UserModel.create(UserFactory(input));
+  const user = await UserModel.create(
+    Object.assign(UserFactory(input), { roles }),
+  );
   const { token, refresh_token } = sign(user);
 
   return { user, token, refresh_token };


### PR DESCRIPTION
### 작업 개요
운동 종목 추가 기능

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `type-graphql`의 `@Authorized` 데코레이터가 권한 문제로 오류를 발생시킬 때 `ForbiddenError`를 반환한다. 여러개 쓰는 것보다 한개로 통일하는게 좋아보여 기존에 생성했었던 `ForbiddenError` 제거
- `TrainingFactory` 추가
- `TrainingFactoryInput` 추가
- `TrainingLimit` 추가
- `Training` 모델에 `name` prop unique로 변경
- `TrainingResolve` 추가
- `createTraining` mutation 추가
  - 테스트 추가
- `UserResolve`의 mutation들 리턴타입 조금 더 명시적으로 수정
- `TrainingInput` 추가
- 테스트 환경에서 사용자 `JWT` 토큰을 반환하던 `signIn` 함수에 사용자 권한을 추가할 수 있도록 수정

resolve #36 

