### PR TITLE
[feat] 운동종목 수정, 삭제

### DIFF
--- a/src/limits/TrainingLimit.ts
+++ b/src/limits/TrainingLimit.ts
@@ -1,4 +1,7 @@
 export const TrainingLimit = {
+  name: {
+    minLength: 1,
+  },
   preference: {
     min: 1,
     max: 10,

--- a/src/resolvers/TrainingResolver.ts
+++ b/src/resolvers/TrainingResolver.ts
@@ -3,14 +3,35 @@ import { Training, TrainingModel } from '@src/models/Training';
 import { TrainingInput } from '@src/resolvers/types/TrainingInput';
 import { EnforceDocument } from 'mongoose';
 import { TrainingMethods } from '@src/models/types/Training';
+import { ObjectId } from 'mongodb';
+import { Role } from '@src/types/enums';
 
 @Resolver(() => Training)
 export class TrainingResolver {
   @Mutation(() => Training, { description: '운동종목 추가' })
-  @Authorized('ADMIN')
+  @Authorized(Role.ADMIN)
   async createTraining(
     @Arg('input') input: TrainingInput,
   ): Promise<EnforceDocument<Training, TrainingMethods>> {
     return TrainingModel.create(input);
+  }
+
+  @Mutation(() => Boolean, { description: '운동종목 수정' })
+  @Authorized(Role.ADMIN)
+  async updateTraining(
+    @Arg('_id') _id: ObjectId,
+    @Arg('input') input: TrainingInput,
+  ): Promise<boolean> {
+    await TrainingModel.findByIdAndUpdate(_id, input).orFail().exec();
+
+    return true;
+  }
+
+  @Mutation(() => Boolean, { description: '운동종목 삭제' })
+  @Authorized(Role.ADMIN)
+  async deleteTraining(@Arg('_id') _id: ObjectId): Promise<boolean> {
+    await TrainingModel.findByIdAndDelete(_id).orFail().exec();
+
+    return true;
   }
 }

--- a/src/resolvers/types/TrainingInput.ts
+++ b/src/resolvers/types/TrainingInput.ts
@@ -9,14 +9,17 @@ import {
   IsUrl,
   Max,
   Min,
+  MinLength,
 } from 'class-validator';
 import { TrainingType } from '@src/types/enums';
+import { TrainingLimit } from '@src/limits/TrainingLimit';
 
 @InputType({ description: '운동종목 추가 입력 객체' })
 export class TrainingInput implements Partial<Training> {
   @Field(() => String, { description: '이름' })
   @IsDefined()
   @IsString()
+  @MinLength(TrainingLimit.name.minLength)
   name: string;
 
   @Field(() => TrainingType, { description: '종류' })


### PR DESCRIPTION
### 작업 개요
관리자 권한을 가지고 있는 사용자가 이미 존재하는 운동종목을 수정 또는 삭제

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `type-graphql`에서 빈 스트링에 대한 유효성 검사를 안함
  - `MinLength` 데코레이터로 확인하는 쪽으로 변경
- `updateTraining`, `deleteTraining` mutation 추가
  - mutation에 관한 테스트 추가

resolve #37 

