### PR TITLE
[refactor] Validation Decorator 수정

### DIFF
--- a/src/limits/TrainingLimit.ts
+++ b/src/limits/TrainingLimit.ts
@@ -1,7 +1,4 @@
 export const TrainingLimit = {
-  name: {
-    minLength: 1,
-  },
   preference: {
     min: 1,
     max: 10,

--- a/src/resolvers/types/LoginInput.ts
+++ b/src/resolvers/types/LoginInput.ts
@@ -1,19 +1,17 @@
 import { User } from '@src/models/User';
 import { Field, InputType } from 'type-graphql';
-import { IsDefined, IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, IsNotEmpty, MinLength } from 'class-validator';
 import { UserLimit } from '@src/limits/UserLimit';
 
 @InputType({ description: '사용자 JWT 토큰 입력 객체' })
 export class LoginInput implements Partial<User> {
   @Field(() => String, { description: '이메일' })
-  @IsDefined()
-  @IsString()
+  @IsNotEmpty()
   @IsEmail()
   email: string;
 
   @Field(() => String, { description: '비밀번호' })
-  @IsDefined()
-  @IsString()
+  @IsNotEmpty()
   @MinLength(UserLimit.password.minLength)
   password: string;
 }

--- a/src/resolvers/types/TrainingInput.ts
+++ b/src/resolvers/types/TrainingInput.ts
@@ -1,51 +1,30 @@
 import { Field, InputType, Int } from 'type-graphql';
 import { Training } from '@src/models/Training';
-import {
-  IsDefined,
-  IsEnum,
-  IsInt,
-  IsOptional,
-  IsString,
-  IsUrl,
-  Max,
-  Min,
-  MinLength,
-} from 'class-validator';
+import { IsNotEmpty, IsUrl, Max, Min } from 'class-validator';
 import { TrainingType } from '@src/types/enums';
-import { TrainingLimit } from '@src/limits/TrainingLimit';
 
 @InputType({ description: '운동종목 추가 입력 객체' })
 export class TrainingInput implements Partial<Training> {
   @Field(() => String, { description: '이름' })
-  @IsDefined()
-  @IsString()
-  @MinLength(TrainingLimit.name.minLength)
+  @IsNotEmpty()
   name: string;
 
   @Field(() => TrainingType, { description: '종류' })
-  @IsDefined()
-  @IsEnum(TrainingType)
   type: TrainingType;
 
   @Field(() => String, { description: '설명', nullable: true })
-  @IsOptional()
-  @IsString()
   description?: string;
 
   @Field(() => Int, { description: '선호도', defaultValue: 1 })
-  @IsOptional()
-  @IsInt()
   @Min(1)
   @Max(10)
   preference?: number;
 
   @Field(() => String, { description: '썸네일 경로', nullable: true })
-  @IsOptional()
   @IsUrl()
   thumbnail_path?: string;
 
   @Field(() => String, { description: '운동영상 경로', nullable: true })
-  @IsOptional()
   @IsUrl()
   video_path?: string;
 }

--- a/src/resolvers/types/UserInput.ts
+++ b/src/resolvers/types/UserInput.ts
@@ -3,12 +3,8 @@ import { User } from '@src/models/User';
 import { Gender } from '@src/types/enums';
 import {
   IsDate,
-  IsDefined,
   IsEmail,
-  IsEnum,
   IsMobilePhone,
-  IsOptional,
-  IsString,
   IsUrl,
   Length,
   MaxDate,
@@ -20,55 +16,39 @@ import { UserLimit } from '@src/limits/UserLimit';
 @InputType({ description: '사용자 입력 객체' })
 export class UserInput implements Partial<User> {
   @Field(() => String, { description: '이름' })
-  @IsDefined()
-  @IsString()
   @Length(UserLimit.name.minLength, UserLimit.name.maxLength)
   name: string;
 
   @Field(() => String, { description: '이메일' })
-  @IsDefined()
-  @IsString()
   @IsEmail()
   email: string;
 
   @Field(() => String, { description: '닉네임' })
-  @IsDefined()
-  @IsString()
   @Length(UserLimit.nickname.minLength, UserLimit.nickname.maxLength)
   nickname: string;
 
   @Field(() => String, { description: '비밀번호' })
-  @IsDefined()
-  @IsString()
   @MinLength(UserLimit.password.minLength)
   password: string;
 
   @Field(() => String, { description: '비밀번호 확인' })
-  @IsDefined()
-  @IsString()
   @MinLength(UserLimit.password.minLength)
   password_confirmation: string;
 
   @Field(() => Gender, { description: '성별' })
-  @IsDefined()
-  @IsEnum(Gender)
   gender: Gender;
 
   @Field(() => Date, { description: '생년월일', nullable: true })
-  @IsOptional()
   @IsDate()
   @MinDate(UserLimit.birth.minDate)
   @MaxDate(UserLimit.birth.maxDate)
   birth?: string;
 
   @Field(() => String, { description: '휴대폰번호', nullable: true })
-  @IsOptional()
-  @IsString()
   @IsMobilePhone('ko-KR')
   tel?: string;
 
   @Field(() => String, { description: '프로필 이미지 경로', nullable: true })
-  @IsOptional()
   @IsUrl()
   profile_image_path?: string;
 }

--- a/src/resolvers/types/VerifyInput.ts
+++ b/src/resolvers/types/VerifyInput.ts
@@ -1,19 +1,15 @@
 import { Field, InputType } from 'type-graphql';
 import { User } from '@src/models/User';
-import { IsDefined, IsEmail, IsString, MinLength } from 'class-validator';
+import { IsEmail, MinLength } from 'class-validator';
 import { UserLimit } from '@src/limits/UserLimit';
 
 @InputType({ description: '사용자 이메일 인증 입력 객체' })
 export class VerifyInput implements Partial<User> {
   @Field(() => String, { description: '이메일' })
-  @IsDefined()
-  @IsString()
   @IsEmail()
   email: string;
 
   @Field(() => String, { description: '이메일 인증 토큰' })
-  @IsDefined()
-  @IsString()
   @MinLength(UserLimit.email_verify_token.minLength)
   email_verify_token: string;
 }


### PR DESCRIPTION
### 작업 개요
유효하지 않거나 필요하지 않은 `Validation Decoratr` 제거 및 수정

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- query나 mutation에서 반드시 필요한 프로퍼티가 값이 undefined라면 `TypeGraphQL`에서 유효성 검사를 하기전에 `GraphQL`에서 `GraphQLError`를 반환한다.
  - 결과적으로는 이를 이용하여 필요없는 데코레이터들을 삭제하거나 수정함
    - `@IsDefined`: `required`인 프로퍼티에 `undefined`나 `null`이 온다면 `GraphQL`에서 에러를 반환하기 때문에 삭제
    - `@IsNotEmpty`: `GraphQL`에서 빈문자열은 검사하지 않는다. `required` 프로퍼티이면서 `string` 타입이면 추가한다.
      - 만약 `@IsEmail`이나 `@Min`, `@Length` 등의 문자열의 추가 검사를 한다면 추가할 필요없다
  - `@IsString`, `@IsInt`, `@IsEnum` 등의 프로퍼티의 타입 검사는 이미 `GraphQL`에서 한다. 필요없다.

### 생각해볼 문제
클라이언트에서 에러를 받을 때 어떤 에러인지 확인하기 어렵다. 추후에 에러핸들링을 통해 좀 더 명시적인 에러를 반환하도록 #52 이슈 등록

resolve #51 

