### PR TITLE
[feat] 운동 계획을 생성

### DIFF
--- a/src/factories/PlanFactory.ts
+++ b/src/factories/PlanFactory.ts
@@ -1,0 +1,18 @@
+import faker from 'faker';
+import { PlanInput } from '@src/resolvers/types/PlanInput';
+import { TrainingFactory } from '@src/factories/TrainingFactory';
+import { SetFactory } from '@src/factories/SetFactory';
+import { TrainingModel } from '@src/models/Training';
+
+export const PlanFactory: (input?: Partial<PlanInput>) => Promise<PlanInput> =
+  async input =>
+    Object.assign(
+      {
+        training: (
+          await TrainingModel.create(TrainingFactory())
+        )._id.toHexString(),
+        plan_date: faker.date.future().toISOString(),
+        sets: [...Array(faker.datatype.number(10))].map(() => SetFactory()),
+      },
+      input,
+    ) as PlanInput;

--- a/src/factories/SetFactory.ts
+++ b/src/factories/SetFactory.ts
@@ -1,0 +1,16 @@
+import faker from 'faker';
+import { SetInput } from '@src/resolvers/types/SetInput';
+
+export const SetFactory: (input?: Partial<SetInput>) => SetInput = input =>
+  Object.assign(
+    faker.random.arrayElement(['anaerobic', 'aerobic']) === 'anaerobic'
+      ? {
+          count: faker.datatype.number(),
+          weight: faker.datatype.float(2),
+        }
+      : {
+          times: faker.datatype.float(2),
+          distances: faker.datatype.float(2),
+        },
+    input,
+  ) as SetInput;

--- a/src/limits/PlanLimit.ts
+++ b/src/limits/PlanLimit.ts
@@ -1,0 +1,19 @@
+export const PlanLimit = {
+  plan_date: {
+    minDate: new Date(1900, 0, 1),
+  },
+  sets: {
+    count: {
+      min: 1,
+    },
+    weight: {
+      min: 1,
+    },
+    times: {
+      min: 1,
+    },
+    distances: {
+      min: 1,
+    },
+  },
+};

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -1,5 +1,12 @@
 import { Field, ObjectType } from 'type-graphql';
-import { getModelForClass, prop, Ref } from '@typegoose/typegoose';
+import {
+  getModelForClass,
+  modelOptions,
+  mongoose,
+  prop,
+  Ref,
+  Severity,
+} from '@typegoose/typegoose';
 import { Model } from '@src/models/Model';
 import { PlanMethods, PlanQueryHelpers } from '@src/models/types/Plan';
 import { User } from '@src/models/User';
@@ -7,6 +14,7 @@ import { Training } from '@src/models/Training';
 import { Set } from '@src/models/Set';
 
 @ObjectType({ implements: Model, description: '운동계획 모델' })
+@modelOptions({ options: { allowMixed: Severity.ALLOW } })
 export class Plan extends Model implements PlanMethods {
   @Field(() => User, { description: '사용자' })
   @prop({ ref: () => User, required: true })
@@ -14,15 +22,15 @@ export class Plan extends Model implements PlanMethods {
 
   @Field(() => Training, { description: '운동종목' })
   @prop({ ref: () => Training, required: true })
-  training: Ref<Training>;
+  training: Ref<Training, string>;
 
   @Field(() => Date, { description: '운동 날짜' })
   @prop({ type: Date, required: true })
-  plan_date: Date;
+  plan_date: string;
 
-  @Field(() => [Set], { description: '세트', nullable: true })
-  @prop({ ref: () => Set })
-  sets?: Ref<Set>[];
+  @Field(() => [Set], { description: '세트', nullable: true, defaultValue: [] })
+  @prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
+  sets?: Set[];
 }
 
 export const PlanModel = getModelForClass<typeof Plan, PlanQueryHelpers>(Plan);

--- a/src/models/Set.ts
+++ b/src/models/Set.ts
@@ -1,16 +1,16 @@
-import { Field, Int, ObjectType } from 'type-graphql';
+import { Field, Float, Int, ObjectType } from 'type-graphql';
 
 @ObjectType({ description: '운동계획의 세트' })
 export class Set {
   @Field(() => Int, { description: '횟수', nullable: true })
   count?: number;
 
-  @Field(() => Int, { description: '무게', nullable: true })
+  @Field(() => Float, { description: '무게(kg)', nullable: true })
   weight?: number;
 
-  @Field(() => Int, { description: '시간(분)', nullable: true })
+  @Field(() => Float, { description: '시간(초)', nullable: true })
   times?: number;
 
-  @Field(() => Int, { description: '거리(km)', nullable: true })
+  @Field(() => Float, { description: '거리(m)', nullable: true })
   distances?: number;
 }

--- a/src/models/Training.ts
+++ b/src/models/Training.ts
@@ -14,7 +14,7 @@ export class Training extends Model implements TrainingMethods {
   name: string;
 
   @Field(() => TrainingType, { description: '종류' })
-  @prop({ enum: TrainingType, required: true })
+  @prop({ enum: TrainingType, type: String, required: true })
   type: TrainingType;
 
   @Field(() => String, { description: '설명', nullable: true })

--- a/src/plugins/jwt.ts
+++ b/src/plugins/jwt.ts
@@ -7,7 +7,7 @@ import { LoginResponse } from '@src/resolvers/types/LoginResponse';
 export const sign = (user: User): LoginResponse => ({
   token: jwt.sign(
     {
-      _id: user._id.toString(),
+      _id: user._id.toHexString(),
     },
     process.env.JWT_SECRET_KEY || '',
     {

--- a/src/resolvers/PlanResolver.ts
+++ b/src/resolvers/PlanResolver.ts
@@ -1,0 +1,52 @@
+import {
+  Arg,
+  Ctx,
+  FieldResolver,
+  Mutation,
+  Resolver,
+  ResolverInterface,
+  Root,
+  UseMiddleware,
+} from 'type-graphql';
+import { Plan, PlanModel } from '@src/models/Plan';
+import { AuthenticateMiddleware } from '@src/middlewares/AuthenticateMiddleware';
+import { PlanInput } from '@src/resolvers/types/PlanInput';
+import { Context } from '@src/context';
+import { Training, TrainingModel } from '@src/models/Training';
+import AuthenticationError from '@src/errors/AuthenticationError';
+import { User, UserModel } from '@src/models/User';
+import { EnforceDocument } from 'mongoose';
+import { PlanMethods } from '@src/models/types/Plan';
+import { UserMethods } from '@src/models/types/User';
+import { TrainingMethods } from '@src/models/types/Training';
+
+@Resolver(() => Plan)
+export class PlanResolver implements ResolverInterface<Plan> {
+  @Mutation(() => Plan, { description: '운동계획 생성' })
+  @UseMiddleware(AuthenticateMiddleware)
+  async createPlan(
+    @Arg('input') input: PlanInput,
+    @Ctx() { user }: Context,
+  ): Promise<EnforceDocument<Plan, PlanMethods>> {
+    if (!user) {
+      throw new AuthenticationError();
+    }
+
+    return PlanModel.create({
+      ...input,
+      user: user._id,
+    } as Plan);
+  }
+
+  @FieldResolver()
+  async user(@Root() plan: Plan): Promise<EnforceDocument<User, UserMethods>> {
+    return await UserModel.findById(plan.user).orFail().exec();
+  }
+
+  @FieldResolver()
+  async training(
+    @Root() plan: Plan,
+  ): Promise<EnforceDocument<Training, TrainingMethods>> {
+    return await TrainingModel.findById(plan.training).orFail().exec();
+  }
+}

--- a/src/resolvers/types/PlanInput.ts
+++ b/src/resolvers/types/PlanInput.ts
@@ -1,0 +1,20 @@
+import { Field, ID, InputType } from 'type-graphql';
+import { IsDate, MinDate, ValidateNested } from 'class-validator';
+import { Plan } from '@src/models/Plan';
+import { SetInput } from '@src/resolvers/types/SetInput';
+import { PlanLimit } from '@src/limits/PlanLimit';
+
+@InputType({ description: '운동 계획 입력 객체' })
+export class PlanInput implements Partial<Plan> {
+  @Field(() => ID, { description: '운동종목' })
+  training: string;
+
+  @Field(() => Date, { description: '운동 날짜' })
+  @IsDate()
+  @MinDate(PlanLimit.plan_date.minDate)
+  plan_date: string;
+
+  @Field(() => [SetInput], { description: '세트', nullable: true })
+  @ValidateNested()
+  sets: SetInput[];
+}

--- a/src/resolvers/types/SetInput.ts
+++ b/src/resolvers/types/SetInput.ts
@@ -1,0 +1,23 @@
+import { Field, Float, InputType, Int } from 'type-graphql';
+import { Set } from '@src/models/Set';
+import { Min } from 'class-validator';
+import { PlanLimit } from '@src/limits/PlanLimit';
+
+@InputType({ description: '세트 입력 객체' })
+export class SetInput implements Partial<Set> {
+  @Field(() => Int, { description: '횟수', nullable: true })
+  @Min(PlanLimit.sets.count.min)
+  count?: number;
+
+  @Field(() => Float, { description: '무게(kg)', nullable: true })
+  @Min(PlanLimit.sets.weight.min)
+  weight?: number;
+
+  @Field(() => Float, { description: '시간(초)', nullable: true })
+  @Min(PlanLimit.sets.times.min)
+  times?: number;
+
+  @Field(() => Float, { description: '거리(m)', nullable: true })
+  @Min(PlanLimit.sets.distances.min)
+  distances?: number;
+}

--- a/tests/feature/create-plans.test.ts
+++ b/tests/feature/create-plans.test.ts
@@ -1,0 +1,182 @@
+import { graphql } from '@tests/graphql';
+import AuthenticationError from '@src/errors/AuthenticationError';
+import { PlanFactory } from '@src/factories/PlanFactory';
+import { signIn } from '@tests/helpers';
+import { ArgumentValidationError } from 'type-graphql';
+import { GraphQLError } from 'graphql';
+import { TrainingFactory } from '@src/factories/TrainingFactory';
+import { TrainingModel } from '@src/models/Training';
+import { PlanLimit } from '@src/limits/PlanLimit';
+
+describe('운동 계획 생성', () => {
+  const createPlanMutation = `mutation createPlan($input: PlanInput!) { createPlan(input: $input) { _id, user { _id, name }, training { _id, name }, plan_date, sets { count, weight } } }`;
+
+  it('로그인 하지 않은 사용자는 요청할 수 없다', async () => {
+    const { errors } = await graphql(createPlanMutation, {
+      input: await PlanFactory(),
+    });
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].originalError).toBeInstanceOf(AuthenticationError);
+    }
+  });
+
+  it('로그인한 사용자는 운동 계획을 생성할 수 있다', async () => {
+    const { token } = await signIn();
+    const { data } = await graphql(
+      createPlanMutation,
+      {
+        input: await PlanFactory(),
+      },
+      token,
+    );
+
+    expect(data?.createPlan).toHaveProperty('_id');
+    expect(data?.createPlan).toHaveProperty(['user', '_id']);
+    expect(data?.createPlan).toHaveProperty(['training', '_id']);
+    expect(data?.createPlan).toHaveProperty('plan_date');
+    expect(data?.createPlan).toHaveProperty('sets');
+  });
+
+  it('사용자 _id를 전달하면 해당 사용자를 저장한다', async () => {
+    const { user, token } = await signIn();
+    const { data } = await graphql(
+      createPlanMutation,
+      {
+        input: await PlanFactory(),
+      },
+      token,
+    );
+
+    expect(user.name === data?.createPlan.user.name).toBeTruthy();
+  });
+
+  it('운동종목 필드는 반드시 필요하다', async () => {
+    const { token } = await signIn();
+    const { errors } = await graphql(
+      createPlanMutation,
+      {
+        input: await PlanFactory({ training: undefined }),
+      },
+      token,
+    );
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0]).toBeInstanceOf(GraphQLError);
+    }
+  });
+
+  it('운동종목 _id를 전달하면 해당 운동종목을 저장한다', async () => {
+    const { token } = await signIn();
+    const training = await TrainingModel.create(TrainingFactory());
+    const { data, errors } = await graphql(
+      createPlanMutation,
+      {
+        input: await PlanFactory({ training: training._id.toHexString() }),
+      },
+      token,
+    );
+
+    expect(errors).toBeUndefined();
+    expect(training.name === data?.createPlan.training.name).toBeTruthy();
+  });
+
+  it('운동 날짜 필드는 반드시 필요하다', async () => {
+    const { token } = await signIn();
+    const { errors } = await graphql(
+      createPlanMutation,
+      {
+        input: await PlanFactory({ plan_date: '' }),
+      },
+      token,
+    );
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].originalError).toBeInstanceOf(ArgumentValidationError);
+    }
+  });
+
+  it(`운동 날짜는 ${PlanLimit.plan_date.minDate.getFullYear()}년 이상 이하이어야 한다`, async () => {
+    const { token } = await signIn();
+    const plan_date = new Date(PlanLimit.plan_date.minDate);
+    plan_date.setDate(plan_date.getDate() - 1);
+
+    const { errors } = await graphql(
+      createPlanMutation,
+      {
+        input: await PlanFactory({
+          plan_date: plan_date.toISOString(),
+        }),
+      },
+      token,
+    );
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors[0].originalError).toBeInstanceOf(ArgumentValidationError);
+    }
+  });
+
+  it('세트는 빈 값을 허용한다', async () => {
+    const { token } = await signIn();
+    const { errors } = await graphql(
+      createPlanMutation,
+      {
+        input: await PlanFactory({ sets: undefined }),
+      },
+      token,
+    );
+
+    expect(errors).toBeUndefined();
+  });
+
+  it('세트의 횟수, 무게, 시간, 거리는 빈 값을 허용한다', async () => {
+    const { token } = await signIn();
+
+    await Promise.all(
+      ['count', 'weight', 'times', 'distances'].map(async field => {
+        const { errors } = await graphql(
+          createPlanMutation,
+          {
+            input: await PlanFactory({ sets: [{ [field]: undefined }] }),
+          },
+          token,
+        );
+
+        expect(errors).toBeUndefined();
+      }),
+    );
+  });
+
+  it(`세트의 횟수는 ${PlanLimit.sets.count.min}개 이상, 무게는 ${PlanLimit.sets.weight.min}kg 이상, 시간은 ${PlanLimit.sets.times.min}초 이상, 거리는 ${PlanLimit.sets.distances.min}m 이상 이어야 한다`, async () => {
+    const { token } = await signIn();
+
+    await Promise.all(
+      Object.entries(PlanLimit.sets).map(async ([key, { min }]) => {
+        const { errors } = await graphql(
+          createPlanMutation,
+          {
+            input: await PlanFactory({
+              sets: [{ [key]: min - 1 }],
+            }),
+          },
+          token,
+        );
+
+        expect(errors).not.toBeUndefined();
+        if (errors) {
+          expect(errors.length).toEqual(1);
+          expect(errors[0].originalError).toBeInstanceOf(
+            ArgumentValidationError,
+          );
+        }
+      }),
+    );
+  });
+});

--- a/tests/feature/get-users.test.ts
+++ b/tests/feature/get-users.test.ts
@@ -57,6 +57,6 @@ describe('사용자 모델', () => {
       token,
     );
 
-    expect(data?.me._id).toEqual(user._id.toString());
+    expect(data?.me._id).toEqual(user._id.toHexString());
   });
 });

--- a/tests/feature/update-training.test.ts
+++ b/tests/feature/update-training.test.ts
@@ -202,7 +202,7 @@ describe('운동종목 삭제', () => {
     const { data, errors } = await graphql(
       deleteTrainingMutation,
       {
-        _id: training._id.toString(),
+        _id: training._id.toHexString(),
       },
       token,
     );
@@ -222,7 +222,7 @@ async function getTrainingMutationVariables(
   const training = await TrainingModel.create(TrainingFactory());
 
   return {
-    _id: training._id.toString(),
+    _id: training._id.toHexString(),
     input: TrainingFactory(input),
   };
 }

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -14,9 +14,10 @@ export async function signIn(
   token: string;
   refresh_token: string;
 }> {
-  const user = await UserModel.create(
-    Object.assign(UserFactory(input), { roles }),
-  );
+  const user = await UserModel.create({
+    ...UserFactory(input),
+    roles,
+  } as UserInput);
   const { token, refresh_token } = sign(user);
 
   return { user, token, refresh_token };


### PR DESCRIPTION
### 작업 개요
운동 계획 생성에 대한 `mutation` 및 테스팅

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- `PlanFactory` 생성
- `SetFactory` 생성
- `PlanInput` 생성
- `SetInput` 생성
  - 제한 `PlanLimit` 생성
- `PlanResolver` 및 `createPlan` `mutation` 생성
  - 관련 테스트 추가
- `Plan` 모델에서 `Set` 모델은 테이블에 저장하지 않기 때문에 `Ref` 키워드를 사용할 수 없고 `Set`는 `mongoose`의 스칼라타입이 아니기 때문에 `type`에 선언할 수 없다. `mongoose.Schema.Types.Mixed` 으로 정의
- `Set` 모델에 무게, 시간, 거리는 `Float` 타입으로 변경
- `_id`에서 `toString` 메서드말고 `toHexString`을 쓰도록 변경

resolve #55 

