### PR TITLE
[feat] 운동 계획 모델에 완료 여부 데이터 추가

### DIFF
--- a/src/factories/PlanFactory.ts
+++ b/src/factories/PlanFactory.ts
@@ -13,6 +13,7 @@ export const PlanFactory: (input?: Partial<PlanInput>) => Promise<PlanInput> =
         )._id.toHexString(),
         plan_date: faker.date.future().toISOString(),
         sets: [...Array(faker.datatype.number(10))].map(() => SetFactory()),
+        complete: faker.datatype.boolean(),
       },
       input,
     ) as PlanInput;

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -37,6 +37,14 @@ export class Plan extends Model implements PlanMethods {
   @prop({ type: [mongoose.Schema.Types.Mixed], default: [] })
   sets?: Set[];
 
+  @Field(() => Boolean, {
+    description: '완료 여부',
+    nullable: true,
+    defaultValue: false,
+  })
+  @prop({ type: Boolean, default: false })
+  complete?: boolean;
+
   @Field(() => Boolean, { description: '수정, 삭제 권한' })
   checkPermission(
     this: DocumentType<Plan>,

--- a/src/resolvers/types/PlanInput.ts
+++ b/src/resolvers/types/PlanInput.ts
@@ -1,5 +1,5 @@
 import { Field, ID, InputType } from 'type-graphql';
-import { IsDate, MinDate, ValidateNested } from 'class-validator';
+import { IsBoolean, IsDate, MinDate, ValidateNested } from 'class-validator';
 import { Plan } from '@src/models/Plan';
 import { SetInput } from '@src/resolvers/types/SetInput';
 import { PlanLimit } from '@src/limits/PlanLimit';
@@ -16,5 +16,9 @@ export class PlanInput implements Partial<Plan> {
 
   @Field(() => [SetInput], { description: '세트', nullable: true })
   @ValidateNested()
-  sets: SetInput[];
+  sets?: SetInput[];
+
+  @Field(() => Boolean, { description: '완료 여부', nullable: true })
+  @IsBoolean()
+  complete?: boolean;
 }

--- a/tests/feature/create-plans.test.ts
+++ b/tests/feature/create-plans.test.ts
@@ -123,17 +123,22 @@ describe('운동 계획 생성', () => {
     }
   });
 
-  it('세트는 빈 값을 허용한다', async () => {
+  it('세트와 완료 여부는 빈 값을 허용한다', async () => {
     const { token } = await signIn();
-    const { errors } = await graphql(
-      createPlanMutation,
-      {
-        input: await PlanFactory({ sets: undefined }),
-      },
-      token,
-    );
 
-    expect(errors).toBeUndefined();
+    await Promise.all(
+      ['sets', 'complete'].map(async field => {
+        const { errors } = await graphql(
+          createPlanMutation,
+          {
+            input: await PlanFactory({ [field]: undefined }),
+          },
+          token,
+        );
+
+        expect(errors).toBeUndefined();
+      }),
+    );
   });
 
   it('세트의 횟수, 무게, 시간, 거리는 빈 값을 허용한다', async () => {


### PR DESCRIPTION
### 작업 개요
`Plan` 모델에 `complete` 필드 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `Plan` 모델에 `complete` 필드 추가
- `PlanInput`에 `complete` 필드 추가
- `PlanFactory`에 `complete` 추가

### 생각해볼 문제
`complete`만 토글하는 `mutation`을 만들어야하나?

resolve #59

