### PR TITLE
[refactor] mongoose ObjectId 로 pk 변경

### DIFF
--- a/src/models/Model.ts
+++ b/src/models/Model.ts
@@ -1,6 +1,5 @@
 import { Field, ID, InterfaceType } from 'type-graphql';
-import { pre, prop } from '@typegoose/typegoose';
-import { ObjectId } from 'mongodb';
+import { mongoose, pre, prop } from '@typegoose/typegoose';
 
 @pre<Model>('save', function () {
   this.updated_at = new Date();
@@ -11,7 +10,7 @@ import { ObjectId } from 'mongodb';
 @InterfaceType()
 export abstract class Model {
   @Field(() => ID)
-  readonly _id: ObjectId;
+  readonly _id: mongoose.Types.ObjectId;
 
   @Field(() => Date, { description: '생성 날짜', defaultValue: new Date() })
   @prop({ type: Date, default: new Date() })

--- a/src/plugins/jwt.ts
+++ b/src/plugins/jwt.ts
@@ -1,7 +1,7 @@
 import jwt from 'jsonwebtoken';
 import { User } from '@src/models/User';
 import randToken from 'rand-token';
-import { ObjectId } from 'mongodb';
+import { mongoose } from '@typegoose/typegoose';
 import { LoginResponse } from '@src/resolvers/types/LoginResponse';
 
 export const sign = (user: User): LoginResponse => ({
@@ -23,11 +23,11 @@ export const verify = (token: string): Partial<User> => {
 
   if (typeof verified === 'string') {
     return {
-      _id: new ObjectId(verified),
+      _id: new mongoose.Types.ObjectId(verified),
     };
   }
 
   return {
-    _id: new ObjectId(verified._id),
+    _id: new mongoose.Types.ObjectId(verified._id),
   };
 };

--- a/src/resolvers/PlanResolver.ts
+++ b/src/resolvers/PlanResolver.ts
@@ -19,7 +19,7 @@ import { EnforceDocument } from 'mongoose';
 import { PlanMethods } from '@src/models/types/Plan';
 import { UserMethods } from '@src/models/types/User';
 import { TrainingMethods } from '@src/models/types/Training';
-import { ObjectId } from 'mongodb';
+import { mongoose } from '@typegoose/typegoose';
 
 @Resolver(() => Plan)
 export class PlanResolver implements ResolverInterface<Plan> {
@@ -42,7 +42,7 @@ export class PlanResolver implements ResolverInterface<Plan> {
   @Mutation(() => Boolean, { description: '운동계획 수정' })
   @UseMiddleware(AuthenticateMiddleware)
   async updatePlan(
-    @Arg('_id') _id: ObjectId,
+    @Arg('_id') _id: mongoose.Types.ObjectId,
     @Arg('input') input: PlanInput,
     @Ctx() { user }: Context,
   ): Promise<boolean> {
@@ -61,7 +61,7 @@ export class PlanResolver implements ResolverInterface<Plan> {
   @Mutation(() => Boolean, { description: '운동계획 삭제' })
   @UseMiddleware(AuthenticateMiddleware)
   async deletePlan(
-    @Arg('_id') _id: ObjectId,
+    @Arg('_id') _id: mongoose.Types.ObjectId,
     @Ctx() { user }: Context,
   ): Promise<boolean> {
     if (!user) {

--- a/src/resolvers/TrainingResolver.ts
+++ b/src/resolvers/TrainingResolver.ts
@@ -3,7 +3,7 @@ import { Training, TrainingModel } from '@src/models/Training';
 import { TrainingInput } from '@src/resolvers/types/TrainingInput';
 import { EnforceDocument } from 'mongoose';
 import { TrainingMethods } from '@src/models/types/Training';
-import { ObjectId } from 'mongodb';
+import { mongoose } from '@typegoose/typegoose';
 import { Role } from '@src/types/enums';
 
 @Resolver(() => Training)
@@ -19,7 +19,7 @@ export class TrainingResolver {
   @Mutation(() => Boolean, { description: '운동종목 수정' })
   @Authorized(Role.ADMIN)
   async updateTraining(
-    @Arg('_id') _id: ObjectId,
+    @Arg('_id') _id: mongoose.Types.ObjectId,
     @Arg('input') input: TrainingInput,
   ): Promise<boolean> {
     await TrainingModel.findByIdAndUpdate(_id, input).orFail().exec();
@@ -29,7 +29,9 @@ export class TrainingResolver {
 
   @Mutation(() => Boolean, { description: '운동종목 삭제' })
   @Authorized(Role.ADMIN)
-  async deleteTraining(@Arg('_id') _id: ObjectId): Promise<boolean> {
+  async deleteTraining(
+    @Arg('_id') _id: mongoose.Types.ObjectId,
+  ): Promise<boolean> {
     await TrainingModel.findByIdAndDelete(_id).orFail().exec();
 
     return true;

--- a/src/scalars/ObjectIdScalar.ts
+++ b/src/scalars/ObjectIdScalar.ts
@@ -1,9 +1,10 @@
 import { GraphQLScalarType, Kind } from 'graphql';
-import { ObjectId } from 'mongodb';
+import { mongoose } from '@typegoose/typegoose';
+import ObjectId = mongoose.Types.ObjectId;
 
 export const ObjectIdScalar = new GraphQLScalarType({
   name: 'ObjectId',
-  description: '몽고의 ObjectID 스칼라 타입',
+  description: 'Mongoose의 ObjectID 스칼라 타입',
   serialize(value: unknown): string {
     if (!(value instanceof ObjectId)) {
       throw new Error('ObjectIdScalar는 ObjectId 값만 직렬화할 수 있습니다');

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,14 +1,14 @@
 import { buildSchema } from 'type-graphql';
 import { TypegooseMiddleware } from '@src/middlewares/TypegooseMiddleware';
-import { ObjectId } from 'mongodb';
-import { ObjectIdScalar } from '@src/scalars/ObjectIdScalar';
 import { GraphQLSchema } from 'graphql';
 import '@src/types/enums';
 import { authChecker } from '@src/auth-checker';
+import { ObjectIdScalar } from '@src/scalars/ObjectIdScalar';
+import { mongoose } from '@typegoose/typegoose';
 
 export const schema: Promise<GraphQLSchema> = buildSchema({
   resolvers: [__dirname + '/**/resolvers/*Resolver.{ts,js}'],
   globalMiddlewares: [TypegooseMiddleware],
-  scalarsMap: [{ type: ObjectId, scalar: ObjectIdScalar }],
+  scalarsMap: [{ type: mongoose.Types.ObjectId, scalar: ObjectIdScalar }],
   authChecker,
 });


### PR DESCRIPTION
### 작업 개요
기존에는 `Model`의 `id`로 `mongodb`의 `ObjectId`를 사용했었는데 `mongoose`에서 여러 타입 에러들이 발생하기 때문에 `mongoose`의 `ObjectId`로 변경

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
`mongodb`의 `ObjectId`를 사용하던 것을 모두 `mongoose`의 `ObjectId`로 변경

resolve #63

