### PR TITLE
[feat] 관계된 모델들이 삭제나 수정을 했을 때의 훅 추가

### DIFF
--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -22,11 +22,11 @@ import { Role } from '@src/types/enums';
 @modelOptions({ options: { allowMixed: Severity.ALLOW } })
 export class Plan extends Model implements PlanMethods {
   @Field(() => User, { description: '사용자' })
-  @prop({ ref: () => User, required: true })
+  @prop({ ref: 'User', required: true })
   user: Ref<User>;
 
   @Field(() => Training, { description: '운동종목' })
-  @prop({ ref: () => Training, required: true })
+  @prop({ ref: 'Training', required: true })
   training: Ref<Training, string>;
 
   @Field(() => Date, { description: '운동 날짜' })

--- a/src/models/Training.ts
+++ b/src/models/Training.ts
@@ -1,12 +1,17 @@
 import { Model } from '@src/models/Model';
 import { Field, Int, ObjectType } from 'type-graphql';
-import { getModelForClass, prop } from '@typegoose/typegoose';
+import { getModelForClass, pre, prop } from '@typegoose/typegoose';
 import { TrainingType } from '@src/types/enums';
 import {
   TrainingMethods,
   TrainingQueryHelpers,
 } from '@src/models/types/Training';
+import { deleteLinkedReferences } from '@src/models/hooks/training-hooks';
 
+@pre<Training>(
+  ['deleteOne', 'deleteMany', 'findOneAndDelete'],
+  deleteLinkedReferences,
+)
 @ObjectType({ implements: Model, description: '운동종목 모델' })
 export class Training extends Model implements TrainingMethods {
   @Field(() => String, { description: '이름' })

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -7,16 +7,19 @@ import {
 } from '@typegoose/typegoose';
 import { Gender, Role } from '@src/types/enums';
 import { Model } from '@src/models/Model';
-import bcrypt from 'bcrypt';
 import { LoginResponse } from '@src/resolvers/types/LoginResponse';
 import { sign } from '@src/plugins/jwt';
 import { UserMethods, UserQueryHelpers } from '@src/models/types/User';
+import {
+  deleteLinkedReferences,
+  hashPassword,
+} from '@src/models/hooks/user-hooks';
 
-@pre<User>('save', async function () {
-  if (this.password) {
-    this.password = await bcrypt.hash(this.password, 12);
-  }
-})
+@pre<User>('save', hashPassword)
+@pre<User>(
+  ['deleteOne', 'deleteMany', 'findOneAndDelete'],
+  deleteLinkedReferences,
+)
 @ObjectType({ implements: Model, description: '사용자 모델' })
 export class User extends Model implements UserMethods {
   @Field(() => String, { description: '이름' })

--- a/src/models/hooks/training-hooks.ts
+++ b/src/models/hooks/training-hooks.ts
@@ -1,0 +1,10 @@
+import { PlanModel } from '@src/models/Plan';
+import { PreFnWithQuery } from '@src/types/hooks';
+import { Training } from '@src/models/Training';
+
+export const deleteLinkedReferences: PreFnWithQuery<Training> =
+  async function () {
+    await PlanModel.deleteMany({
+      training: this.getFilter()._id?.toString(),
+    });
+  };

--- a/src/models/hooks/user-hooks.ts
+++ b/src/models/hooks/user-hooks.ts
@@ -1,0 +1,14 @@
+import { PlanModel } from '@src/models/Plan';
+import { User } from '@src/models/User';
+import { PreFnWithDocumentType, PreFnWithQuery } from '@src/types/hooks';
+import bcrypt from 'bcrypt';
+
+export const hashPassword: PreFnWithDocumentType<User> = async function () {
+  if (this.password) {
+    this.password = await bcrypt.hash(this.password, 12);
+  }
+};
+
+export const deleteLinkedReferences: PreFnWithQuery<User> = async function () {
+  await PlanModel.deleteMany({ user: this.getFilter()._id });
+};

--- a/src/types/hooks.d.ts
+++ b/src/types/hooks.d.ts
@@ -1,0 +1,13 @@
+import { DocumentType } from '@typegoose/typegoose/lib/types';
+import { Query } from 'mongoose';
+
+declare type ReturnVoid = void | Promise<void>;
+declare type HookNextErrorFn = (err?: Error) => ReturnVoid;
+declare type PreFnWithDocumentType<T> = (
+  this: DocumentType<T>,
+  next: HookNextErrorFn,
+) => ReturnVoid;
+declare type PreFnWithQuery<T> = (
+  this: Query<unknown, DocumentType<T>>,
+  next: (error?: Error) => ReturnVoid,
+) => ReturnVoid;

--- a/tests/feature/registeration.test.ts
+++ b/tests/feature/registeration.test.ts
@@ -5,7 +5,6 @@ import { GraphQLError } from 'graphql';
 import { UserModel } from '@src/models/User';
 import { ArgumentValidationError, ForbiddenError } from 'type-graphql';
 import { UserInputError } from 'apollo-server';
-import bcrypt from 'bcrypt';
 import { signIn } from '@tests/helpers';
 
 describe('회원가입을 할 수 있다', () => {
@@ -228,17 +227,6 @@ describe('회원가입을 할 수 있다', () => {
       expect(errors.length).toEqual(1);
       expect(errors[0].originalError).toBeInstanceOf(ArgumentValidationError);
     }
-  });
-
-  it('데이터 베이스에 사용자 정보를 저장하기 전에 비밀번호를 해쉬화 한다', async () => {
-    const input = UserFactory();
-    const { data } = await graphql(registerMutation, {
-      input,
-    });
-
-    expect(
-      await bcrypt.compare(input.password, data?.register.password),
-    ).toBeTruthy();
   });
 
   it('유효성 검사에 통과되면 사용자 입력 데이터를 데이터 베이스에 추가한다', async () => {

--- a/tests/unit/training.test.ts
+++ b/tests/unit/training.test.ts
@@ -1,8 +1,33 @@
-import { Training } from '@src/models/Training';
+import { Training, TrainingModel } from '@src/models/Training';
 import { Model } from '@src/models/Model';
+import { Plan, PlanModel } from '@src/models/Plan';
+import { PlanFactory } from '@src/factories/PlanFactory';
+import { TrainingFactory } from '@src/factories/TrainingFactory';
+import { UserModel } from '@src/models/User';
+import { UserFactory } from '@src/factories/UserFactory';
 
 describe('운동종목 모델', () => {
   it('Model을 상속받고 있다', () => {
     expect(Object.getPrototypeOf(Training)).toEqual(Model);
+  });
+
+  it('운동종목을 삭제하면 해당 종목으로 추가된 모든 운동 계획들이 삭제된다', async () => {
+    const count = 5;
+    const training = await TrainingModel.create(TrainingFactory());
+    await Promise.all(
+      [...Array(count)].map(async () =>
+        PlanModel.create({
+          ...(await PlanFactory()),
+          user: (await UserModel.create(UserFactory()))._id,
+          training: training._id.toHexString(),
+        } as Plan),
+      ),
+    );
+
+    expect(await PlanModel.find().count().exec()).toEqual(count);
+
+    await TrainingModel.findByIdAndDelete(training._id);
+
+    expect(await PlanModel.find().count().exec()).toEqual(0);
   });
 });

--- a/tests/unit/user.test.ts
+++ b/tests/unit/user.test.ts
@@ -1,6 +1,10 @@
 import { User, UserModel } from '@src/models/User';
 import { Model } from '@src/models/Model';
 import { UserFactory } from '@src/factories/UserFactory';
+import { Plan, PlanModel } from '@src/models/Plan';
+import { PlanFactory } from '@src/factories/PlanFactory';
+import { graphql } from '@tests/graphql';
+import bcrypt from 'bcrypt';
 
 describe('사용자 모델', () => {
   it('Model을 상속받고 있다', () => {
@@ -16,5 +20,45 @@ describe('사용자 모델', () => {
 
     expect(beforeRefreshToken === refresh_token).toBeFalsy();
     expect(token).not.toBeUndefined();
+  });
+
+  it('데이터 베이스에 사용자 정보를 저장하기 전에 비밀번호를 해쉬화 한다', async () => {
+    const input = UserFactory();
+    const { data } = await graphql(
+      `
+        mutation register($input: UserInput!) {
+          register(input: $input) {
+            _id
+            password
+          }
+        }
+      `,
+      {
+        input,
+      },
+    );
+
+    expect(
+      await bcrypt.compare(input.password, data?.register.password),
+    ).toBeTruthy();
+  });
+
+  it('사용자를 삭제하면 해당 사용자로 추가된 모든 운동 계획들이 삭제된다', async () => {
+    const count = 5;
+    const user = await UserModel.create(UserFactory());
+    await Promise.all(
+      [...Array(count)].map(async () =>
+        PlanModel.create({
+          ...(await PlanFactory()),
+          user: user._id,
+        } as Plan),
+      ),
+    );
+
+    expect(await PlanModel.find().count().exec()).toEqual(count);
+
+    await UserModel.findByIdAndDelete(user._id);
+
+    expect(await PlanModel.find().count().exec()).toEqual(0);
   });
 });


### PR DESCRIPTION
### 작업 개요
`User` 모델과 `Training` 모델이 삭제되었을 때 연결된 `Plan` 모델들도 같이 삭제

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `delete` 훅에서 다른 모델을 삭제하려고 하면 `Option "ref" for "Plan.user" is null/undefined! [E005]` 에러가 발생한다. [구글링](https://github.com/typegoose/typegoose/issues/427) 해보니 문자열로 하드코딩하면 문제가 해결됨
- `Training` 훅 추가
- `User` 훅 추가
- 관련 테스트 추가

resolve #62 

