### PR TITLE
[feat] 모든 운동 계획 가져오는 query 추가

### DIFF
--- a/src/resolvers/PlanResolver.ts
+++ b/src/resolvers/PlanResolver.ts
@@ -3,6 +3,7 @@ import {
   Ctx,
   FieldResolver,
   Mutation,
+  Query,
   Resolver,
   ResolverInterface,
   Root,
@@ -23,6 +24,18 @@ import { mongoose } from '@typegoose/typegoose';
 
 @Resolver(() => Plan)
 export class PlanResolver implements ResolverInterface<Plan> {
+  @Query(() => [Plan], { description: '사용자의 모든 운동 계획 조회' })
+  @UseMiddleware(AuthenticateMiddleware)
+  async plans(
+    @Ctx() { user }: Context,
+  ): Promise<EnforceDocument<Plan, PlanMethods>[]> {
+    if (!user) {
+      throw new AuthenticationError();
+    }
+
+    return PlanModel.find({ user: user._id });
+  }
+
   @Mutation(() => Plan, { description: '운동계획 생성' })
   @UseMiddleware(AuthenticateMiddleware)
   async createPlan(

--- a/tests/feature/get-plans.test.ts
+++ b/tests/feature/get-plans.test.ts
@@ -1,0 +1,36 @@
+import { graphql } from '@tests/graphql';
+import AuthenticationError from '@src/errors/AuthenticationError';
+import { PlanFactory } from '@src/factories/PlanFactory';
+import { signIn } from '@tests/helpers';
+import { Plan, PlanModel } from '@src/models/Plan';
+
+describe('운동 계획 조회', () => {
+  const plansQuery = `query plans { plans { _id } }`;
+
+  it('로그인 하지 않은 사용자는 모든 운동 계획을 조회할 수 없다', async () => {
+    const { errors } = await graphql(plansQuery);
+
+    expect(errors).not.toBeUndefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0].originalError).toBeInstanceOf(AuthenticationError);
+    }
+  });
+
+  it('로그인한 사용자는 자신의 모든 운동 계획들을 조회할 수 있다', async () => {
+    const count = 5;
+    const { user, token } = await signIn();
+    await Promise.all(
+      [...Array(count)].map(async () => {
+        await PlanModel.create({
+          ...(await PlanFactory()),
+          user: user._id,
+        } as Plan);
+      }),
+    );
+    const { data, errors } = await graphql(plansQuery, undefined, token);
+
+    expect(errors).toBeUndefined();
+    expect(data?.plans.length).toEqual(count);
+  });
+});

--- a/tests/feature/get-users.test.ts
+++ b/tests/feature/get-users.test.ts
@@ -4,7 +4,7 @@ import { graphql } from '@tests/graphql';
 import { signIn } from '@tests/helpers';
 import AuthenticationError from '@src/errors/AuthenticationError';
 
-describe('사용자 모델', () => {
+describe('사용자 조회', () => {
   it('모든 사용자를 조회할 수 있다', async () => {
     const count = 5;
 


### PR DESCRIPTION
### 작업 개요
`plans` `query` 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `PlanResolver`에 `plans` `query` 추가
- 관련 테스트 추가

resolve #60 

