### PR TITLE
[style] 각 Input 인스턴스 성격에 맞게 이름 변경

### DIFF
--- a/src/factories/PlanFactory.ts
+++ b/src/factories/PlanFactory.ts
@@ -1,19 +1,20 @@
 import faker from 'faker';
-import { PlanInput } from '@src/resolvers/types/PlanInput';
+import { CreatePlanInput } from '@src/resolvers/types/CreatePlanInput';
 import { TrainingFactory } from '@src/factories/TrainingFactory';
 import { SetFactory } from '@src/factories/SetFactory';
 import { TrainingModel } from '@src/models/Training';
 
-export const PlanFactory: (input?: Partial<PlanInput>) => Promise<PlanInput> =
-  async input =>
-    Object.assign(
-      {
-        training: (
-          await TrainingModel.create(TrainingFactory())
-        )._id.toHexString(),
-        plan_date: faker.date.future().toISOString(),
-        sets: [...Array(faker.datatype.number(10))].map(() => SetFactory()),
-        complete: faker.datatype.boolean(),
-      } as PlanInput,
-      input,
-    );
+export const PlanFactory: (
+  input?: Partial<CreatePlanInput>,
+) => Promise<CreatePlanInput> = async input =>
+  Object.assign(
+    {
+      training: (
+        await TrainingModel.create(TrainingFactory())
+      )._id.toHexString(),
+      plan_date: faker.date.future().toISOString(),
+      sets: [...Array(faker.datatype.number(10))].map(() => SetFactory()),
+      complete: faker.datatype.boolean(),
+    } as CreatePlanInput,
+    input,
+  );

--- a/src/factories/TrainingFactory.ts
+++ b/src/factories/TrainingFactory.ts
@@ -1,11 +1,11 @@
 import faker from 'faker';
 import { TrainingType } from '@src/types/enums';
-import { TrainingInput } from '@src/resolvers/types/TrainingInput';
+import { CreateTrainingInput } from '@src/resolvers/types/CreateTrainingInput';
 import { TrainingLimit } from '@src/limits/TrainingLimit';
 
 export const TrainingFactory: (
-  input?: Partial<TrainingInput>,
-) => TrainingInput = input =>
+  input?: Partial<CreateTrainingInput>,
+) => CreateTrainingInput = input =>
   Object.assign(
     {
       name: faker.unique(faker.name.lastName),
@@ -26,6 +26,6 @@ export const TrainingFactory: (
       }),
       thumbnail_path: faker.image.imageUrl(64, 64),
       video_path: faker.image.imageUrl(64, 64),
-    } as TrainingInput,
+    } as CreateTrainingInput,
     input,
   );

--- a/src/factories/UserFactory.ts
+++ b/src/factories/UserFactory.ts
@@ -1,28 +1,29 @@
 import faker from 'faker';
-import { UserInput } from '@src/resolvers/types/UserInput';
+import { RegisterInput } from '@src/resolvers/types/RegisterInput';
 import { UserLimit } from '@src/limits/UserLimit';
 import { Gender } from '@src/types/enums';
 
-export const UserFactory: (input?: Partial<UserInput>) => UserInput = input => {
-  const password = faker.internet.password(UserLimit.password.minLength);
+export const UserFactory: (input?: Partial<RegisterInput>) => RegisterInput =
+  input => {
+    const password = faker.internet.password(UserLimit.password.minLength);
 
-  return Object.assign(
-    {
-      name: faker.name.lastName() + faker.name.firstName(),
-      email: `${faker.unique(faker.random.words, [1])}@${
-        faker.internet.email().split('@')[1]
-      }`,
-      nickname: faker.unique(faker.name.firstName),
-      password,
-      password_confirmation: password,
-      gender: faker.random.arrayElement([Gender.MALE, Gender.FEMALE]),
-      birth: faker.date
-        .between(UserLimit.birth.minDate, UserLimit.birth.maxDate)
-        .toISOString(),
-      tel: faker.phone.phoneNumber('010-####-####'),
-      profile_image_path: faker.image.imageUrl(64, 64),
-      device_id: faker.internet.mac(),
-    } as UserInput,
-    input,
-  );
-};
+    return Object.assign(
+      {
+        name: faker.name.lastName() + faker.name.firstName(),
+        email: `${faker.unique(faker.random.words, [1])}@${
+          faker.internet.email().split('@')[1]
+        }`,
+        nickname: faker.unique(faker.name.firstName),
+        password,
+        password_confirmation: password,
+        gender: faker.random.arrayElement([Gender.MALE, Gender.FEMALE]),
+        birth: faker.date
+          .between(UserLimit.birth.minDate, UserLimit.birth.maxDate)
+          .toISOString(),
+        tel: faker.phone.phoneNumber('010-####-####'),
+        profile_image_path: faker.image.imageUrl(64, 64),
+        device_id: faker.internet.mac(),
+      } as RegisterInput,
+      input,
+    );
+  };

--- a/src/resolvers/PlanResolver.ts
+++ b/src/resolvers/PlanResolver.ts
@@ -11,7 +11,7 @@ import {
 } from 'type-graphql';
 import { Plan, PlanModel } from '@src/models/Plan';
 import { AuthenticateMiddleware } from '@src/middlewares/AuthenticateMiddleware';
-import { PlanInput } from '@src/resolvers/types/PlanInput';
+import { CreatePlanInput } from '@src/resolvers/types/CreatePlanInput';
 import { Context } from '@src/context';
 import { Training, TrainingModel } from '@src/models/Training';
 import AuthenticationError from '@src/errors/AuthenticationError';
@@ -21,6 +21,7 @@ import { UserQueryHelpers } from '@src/models/types/User';
 import { TrainingQueryHelpers } from '@src/models/types/Training';
 import { DocumentType, mongoose } from '@typegoose/typegoose';
 import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
+import { UpdatePlanInput } from '@src/resolvers/types/UpdatePlanInput';
 
 @Resolver(() => Plan)
 export class PlanResolver implements ResolverInterface<Plan> {
@@ -39,7 +40,7 @@ export class PlanResolver implements ResolverInterface<Plan> {
   @Mutation(() => Plan, { description: '운동계획 생성' })
   @UseMiddleware(AuthenticateMiddleware)
   async createPlan(
-    @Arg('input') input: PlanInput,
+    @Arg('input') input: CreatePlanInput,
     @Ctx() { user }: Context,
   ): Promise<DocumentType<Plan, PlanQueryHelpers>> {
     if (!user) {
@@ -56,7 +57,7 @@ export class PlanResolver implements ResolverInterface<Plan> {
   @UseMiddleware(AuthenticateMiddleware)
   async updatePlan(
     @Arg('_id') _id: mongoose.Types.ObjectId,
-    @Arg('input') input: PlanInput,
+    @Arg('input') input: UpdatePlanInput,
     @Ctx() { user }: Context,
   ): Promise<boolean> {
     if (!user) {

--- a/src/resolvers/TrainingResolver.ts
+++ b/src/resolvers/TrainingResolver.ts
@@ -1,17 +1,18 @@
 import { Arg, Authorized, Mutation, Resolver } from 'type-graphql';
 import { Training, TrainingModel } from '@src/models/Training';
-import { TrainingInput } from '@src/resolvers/types/TrainingInput';
+import { CreateTrainingInput } from '@src/resolvers/types/CreateTrainingInput';
 import { TrainingQueryHelpers } from '@src/models/types/Training';
 import { DocumentType, mongoose } from '@typegoose/typegoose';
 import { Role } from '@src/types/enums';
 import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
+import { UpdateTrainingInput } from '@src/resolvers/types/UpdateTrainingInput';
 
 @Resolver(() => Training)
 export class TrainingResolver {
   @Mutation(() => Training, { description: '운동종목 추가' })
   @Authorized(Role.ADMIN)
   async createTraining(
-    @Arg('input') input: TrainingInput,
+    @Arg('input') input: CreateTrainingInput,
   ): Promise<DocumentType<Training, TrainingQueryHelpers>> {
     return TrainingModel.create(input);
   }
@@ -20,7 +21,7 @@ export class TrainingResolver {
   @Authorized(Role.ADMIN)
   async updateTraining(
     @Arg('_id') _id: mongoose.Types.ObjectId,
-    @Arg('input') input: TrainingInput,
+    @Arg('input') input: UpdateTrainingInput,
   ): Promise<boolean> {
     await TrainingModel.findByIdAndUpdate(_id, input)
       .orFail(new DocumentNotFoundError())

--- a/src/resolvers/UserResolver.ts
+++ b/src/resolvers/UserResolver.ts
@@ -7,7 +7,7 @@ import {
   Resolver,
   UseMiddleware,
 } from 'type-graphql';
-import { UserInput } from '@src/resolvers/types/UserInput';
+import { RegisterInput } from '@src/resolvers/types/RegisterInput';
 import bcrypt from 'bcrypt';
 import { UserInputError } from 'apollo-server';
 import { LoginInput } from '@src/resolvers/types/LoginInput';
@@ -59,7 +59,7 @@ export class UserResolver {
   @Mutation(() => AuthenticationResponse, { description: '사용자 생성' })
   @UseMiddleware(GuestMiddleware)
   async register(
-    @Arg('input') input: UserInput,
+    @Arg('input') input: RegisterInput,
   ): Promise<AuthenticationResponse> {
     if (input.password !== input.password_confirmation) {
       throw new UserInputError('비밀번호와 비밀번호 확인 값이 다릅니다');

--- a/src/resolvers/types/CreatePlanInput.ts
+++ b/src/resolvers/types/CreatePlanInput.ts
@@ -5,7 +5,7 @@ import { SetInput } from '@src/resolvers/types/SetInput';
 import { PlanLimit } from '@src/limits/PlanLimit';
 
 @InputType({ description: '운동 계획 입력 객체' })
-export class PlanInput implements Partial<Plan> {
+export class CreatePlanInput implements Partial<Plan> {
   @Field(() => ID, { description: '운동종목' })
   training: string;
 

--- a/src/resolvers/types/CreateTrainingInput.ts
+++ b/src/resolvers/types/CreateTrainingInput.ts
@@ -1,0 +1,30 @@
+import { Field, InputType, Int } from 'type-graphql';
+import { Training } from '@src/models/Training';
+import { IsNotEmpty, IsUrl, Max, Min } from 'class-validator';
+import { TrainingType } from '@src/types/enums';
+
+@InputType({ description: '운동종목 추가 입력 객체' })
+export class CreateTrainingInput implements Partial<Training> {
+  @Field(() => String, { description: '이름' })
+  @IsNotEmpty()
+  name: string;
+
+  @Field(() => TrainingType, { description: '종류' })
+  type: TrainingType;
+
+  @Field(() => String, { description: '설명', nullable: true })
+  description?: string;
+
+  @Field(() => Int, { description: '선호도', defaultValue: 1 })
+  @Min(1)
+  @Max(10)
+  preference?: number;
+
+  @Field(() => String, { description: '썸네일 경로', nullable: true })
+  @IsUrl()
+  thumbnail_path?: string;
+
+  @Field(() => String, { description: '운동영상 경로', nullable: true })
+  @IsUrl()
+  video_path?: string;
+}

--- a/src/resolvers/types/RegisterInput.ts
+++ b/src/resolvers/types/RegisterInput.ts
@@ -15,7 +15,7 @@ import {
 import { UserLimit } from '@src/limits/UserLimit';
 
 @InputType({ description: '사용자 입력 객체' })
-export class UserInput implements Partial<User> {
+export class RegisterInput implements Partial<User> {
   @Field(() => String, { description: '이름' })
   @Length(UserLimit.name.minLength, UserLimit.name.maxLength)
   name: string;

--- a/src/resolvers/types/UpdatePlanInput.ts
+++ b/src/resolvers/types/UpdatePlanInput.ts
@@ -1,0 +1,24 @@
+import { Field, ID, InputType } from 'type-graphql';
+import { IsBoolean, IsDate, MinDate, ValidateNested } from 'class-validator';
+import { Plan } from '@src/models/Plan';
+import { SetInput } from '@src/resolvers/types/SetInput';
+import { PlanLimit } from '@src/limits/PlanLimit';
+
+@InputType({ description: '운동 계획 입력 객체' })
+export class UpdatePlanInput implements Partial<Plan> {
+  @Field(() => ID, { description: '운동종목', nullable: true })
+  training?: string;
+
+  @Field(() => Date, { description: '운동 날짜', nullable: true })
+  @IsDate()
+  @MinDate(PlanLimit.plan_date.minDate)
+  plan_date?: string;
+
+  @Field(() => [SetInput], { description: '세트', nullable: true })
+  @ValidateNested()
+  sets?: SetInput[];
+
+  @Field(() => Boolean, { description: '완료 여부', nullable: true })
+  @IsBoolean()
+  complete?: boolean;
+}

--- a/src/resolvers/types/UpdateTrainingInput.ts
+++ b/src/resolvers/types/UpdateTrainingInput.ts
@@ -4,13 +4,13 @@ import { IsNotEmpty, IsUrl, Max, Min } from 'class-validator';
 import { TrainingType } from '@src/types/enums';
 
 @InputType({ description: '운동종목 추가 입력 객체' })
-export class TrainingInput implements Partial<Training> {
-  @Field(() => String, { description: '이름' })
+export class UpdateTrainingInput implements Partial<Training> {
+  @Field(() => String, { description: '이름', nullable: true })
   @IsNotEmpty()
-  name: string;
+  name?: string;
 
-  @Field(() => TrainingType, { description: '종류' })
-  type: TrainingType;
+  @Field(() => TrainingType, { description: '종류', nullable: true })
+  type?: TrainingType;
 
   @Field(() => String, { description: '설명', nullable: true })
   description?: string;

--- a/tests/feature/create-plans.test.ts
+++ b/tests/feature/create-plans.test.ts
@@ -9,7 +9,7 @@ import { PlanLimit } from '@src/limits/PlanLimit';
 import ValidationError from '@src/errors/ValidationError';
 
 describe('운동 계획 생성', () => {
-  const createPlanMutation = `mutation createPlan($input: PlanInput!) { createPlan(input: $input) { _id, user { _id, name }, training { _id, name }, plan_date, sets { count, weight } } }`;
+  const createPlanMutation = `mutation createPlan($input: CreatePlanInput!) { createPlan(input: $input) { _id, user { _id, name }, training { _id, name }, plan_date, sets { count, weight } } }`;
 
   it('로그인 하지 않은 사용자는 요청할 수 없다', async () => {
     const { errors } = await graphql(createPlanMutation, {

--- a/tests/feature/create-training.test.ts
+++ b/tests/feature/create-training.test.ts
@@ -10,7 +10,7 @@ import ValidationError from '@src/errors/ValidationError';
 import AuthenticationError from '@src/errors/AuthenticationError';
 
 describe('운동종목 추가', () => {
-  const createTrainingMutation = `mutation createTraining($input: TrainingInput!) { createTraining(input: $input) { _id } }`;
+  const createTrainingMutation = `mutation createTraining($input: CreateTrainingInput!) { createTraining(input: $input) { _id } }`;
 
   it('로그인 하지 않으면 추가할 수 없다', async () => {
     const { errors } = await graphql(createTrainingMutation, {

--- a/tests/feature/registeration.test.ts
+++ b/tests/feature/registeration.test.ts
@@ -9,7 +9,7 @@ import ForbiddenError from '@src/errors/ForbiddenError';
 import ValidationError from '@src/errors/ValidationError';
 
 describe('회원가입을 할 수 있다', () => {
-  const registerMutation = `mutation register($input: UserInput!) { register(input: $input) { user { _id, password } } }`;
+  const registerMutation = `mutation register($input: RegisterInput!) { register(input: $input) { user { _id, password } } }`;
   const existUserQuery = `query existUser($field: String!, $value: String!) { existUser(field: $field, value: $value) }`;
 
   it('로그인한 사용자는 요청할 수 없다', async () => {

--- a/tests/feature/update-plans.test.ts
+++ b/tests/feature/update-plans.test.ts
@@ -4,7 +4,6 @@ import AuthenticationError from '@src/errors/AuthenticationError';
 import { Plan, PlanModel } from '@src/models/Plan';
 import { User, UserModel } from '@src/models/User';
 import { UserFactory } from '@src/factories/UserFactory';
-import { PlanInput } from '@src/resolvers/types/PlanInput';
 import { PlanQueryHelpers } from '@src/models/types/Plan';
 import { signIn } from '@tests/helpers';
 import { UserQueryHelpers } from '@src/models/types/User';
@@ -15,9 +14,10 @@ import { DocumentType } from '@typegoose/typegoose';
 import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
 import ForbiddenError from '@src/errors/ForbiddenError';
 import ValidationError from '@src/errors/ValidationError';
+import { UpdatePlanInput } from '@src/resolvers/types/UpdatePlanInput';
 
 describe('운동 계획 수정', () => {
-  const updatePlanMutation = `mutation updatePlan($_id: ObjectId!, $input: PlanInput!) { updatePlan(_id: $_id, input: $input) }`;
+  const updatePlanMutation = `mutation updatePlan($_id: ObjectId!, $input: UpdatePlanInput!) { updatePlan(_id: $_id, input: $input) }`;
 
   it('로그인 하지 않은 사용자는 수정 요청할 수 없다', async () => {
     const plan = await getPlan();
@@ -211,7 +211,7 @@ describe('운동 계획 삭제', () => {
 });
 
 async function getPlan(
-  input?: Partial<PlanInput>,
+  input?: UpdatePlanInput,
   user?: DocumentType<User, UserQueryHelpers>,
 ): Promise<DocumentType<Plan, PlanQueryHelpers>> {
   return PlanModel.create({

--- a/tests/feature/update-trainings.test.ts
+++ b/tests/feature/update-trainings.test.ts
@@ -3,15 +3,14 @@ import { TrainingFactory } from '@src/factories/TrainingFactory';
 import { signIn } from '@tests/helpers';
 import { Role } from '@src/types/enums';
 import { TrainingModel } from '@src/models/Training';
-import { GraphQLError } from 'graphql';
 import { TrainingLimit } from '@src/limits/TrainingLimit';
-import { TrainingInput } from '@src/resolvers/types/TrainingInput';
 import ForbiddenError from '@src/errors/ForbiddenError';
 import ValidationError from '@src/errors/ValidationError';
 import AuthenticationError from '@src/errors/AuthenticationError';
+import { UpdateTrainingInput } from '@src/resolvers/types/UpdateTrainingInput';
 
 describe('운동종목 수정', () => {
-  const updateTrainingMutation = `mutation updateTraining($_id: ObjectId!, $input: TrainingInput!) { updateTraining(_id: $_id, input: $input) }`;
+  const updateTrainingMutation = `mutation updateTraining($_id: ObjectId!, $input: UpdateTrainingInput!) { updateTraining(_id: $_id, input: $input) }`;
 
   it('로그인 하지 않으면 수정할 수 없다', async () => {
     const { errors } = await graphql(
@@ -82,21 +81,6 @@ describe('운동종목 수정', () => {
     if (errors) {
       expect(errors.length).toEqual(1);
       expect(errors[0].message).toContain('E11000 duplicate key error dup key');
-    }
-  });
-
-  it('종류 필드는 반드시 필요하다', async () => {
-    const { token } = await signIn(undefined, [Role.ADMIN]);
-    const { errors } = await graphql(
-      updateTrainingMutation,
-      await getTrainingMutationVariables({ type: undefined }),
-      token,
-    );
-
-    expect(errors).toBeDefined();
-    if (errors) {
-      expect(errors.length).toEqual(1);
-      expect(errors[0]).toBeInstanceOf(GraphQLError);
     }
   });
 
@@ -209,10 +193,10 @@ describe('운동종목 삭제', () => {
 });
 
 async function getTrainingMutationVariables(
-  input?: Partial<TrainingInput>,
+  input?: UpdateTrainingInput,
 ): Promise<{
   _id: string;
-  input: TrainingInput;
+  input: UpdateTrainingInput;
 }> {
   const training = await TrainingModel.create(TrainingFactory());
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -3,11 +3,11 @@ import { UserFactory } from '@src/factories/UserFactory';
 import { sign } from '@src/plugins/jwt';
 import { UserQueryHelpers } from '@src/models/types/User';
 import { Role } from '@src/types/enums';
-import { UserInput } from '@src/resolvers/types/UserInput';
+import { RegisterInput } from '@src/resolvers/types/RegisterInput';
 import { DocumentType } from '@typegoose/typegoose';
 
 export async function signIn(
-  input?: Partial<UserInput>,
+  input?: Partial<RegisterInput>,
   roles?: Role[],
 ): Promise<{
   user: DocumentType<User, UserQueryHelpers>;
@@ -17,7 +17,7 @@ export async function signIn(
   const user = await UserModel.create({
     ...UserFactory(input),
     roles,
-  } as UserInput);
+  } as RegisterInput);
   const { token, refresh_token } = sign(user);
 
   return { user, token, refresh_token };

--- a/tests/unit/user.test.ts
+++ b/tests/unit/user.test.ts
@@ -29,7 +29,7 @@ describe('사용자 모델', () => {
     const input = UserFactory();
     const { data } = await graphql(
       `
-        mutation register($input: UserInput!) {
+        mutation register($input: RegisterInput!) {
           register(input: $input) {
             user {
               _id


### PR DESCRIPTION
### 작업 개요
각 Input 인스턴스 성격에 맞게 이름 변경

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- `PlanInput` -> `CreatePlanInput` 이름 변경
- 모든 필드가 `nullable`인 `UpdatePlanInput` 생성
- `TrainingInput` -> `CreateTrainingInput` 이름 변경
- 모든 필드가 `nullable`인 `UpdateTrainingInput` 생성
- `UserInput` -> `RegisterInput` 이름 변경
- 관련 테스트 수정

resolve #91

