### PR TITLE
[feat] Plan 모델에 훅을 추가하여 최대 무게 토글

### DIFF
--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -1,4 +1,4 @@
-import { Field, ObjectType } from 'type-graphql';
+import { Field, Float, ObjectType } from 'type-graphql';
 import {
   DocumentType,
   getModelForClass,
@@ -48,8 +48,8 @@ export class Plan extends Model implements PlanMethods {
   @prop({ type: Boolean, default: false })
   complete: boolean;
 
-  @Field(() => Number, { description: '1rm', defaultValue: 0 })
-  @prop({ type: Number, default: 0 })
+  @Field(() => Float, { description: '1rm', defaultValue: 0 })
+  @prop({ type: Float, default: 0 })
   one_rm: number;
 
   checkPermission(

--- a/src/models/hooks/plan-hooks.ts
+++ b/src/models/hooks/plan-hooks.ts
@@ -1,0 +1,20 @@
+import { PreFnWithQuery } from '@src/types/hooks';
+import { Plan, PlanModel } from '@src/models/Plan';
+import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
+import { UpdateQuery, UpdateWithAggregationPipeline } from 'mongoose';
+
+const isCompleteUpdateQuery = <T>(
+  update: UpdateQuery<T> | UpdateWithAggregationPipeline | null,
+): update is UpdateQuery<T> =>
+  (update as UpdateQuery<T>).complete !== undefined;
+
+export const toggleOneRM: PreFnWithQuery<Plan> = async function () {
+  const plan = await PlanModel.findById(this.getFilter()._id).orFail(
+    new DocumentNotFoundError(),
+  );
+  const update = this.getUpdate();
+
+  if (isCompleteUpdateQuery(update) && plan.complete !== update.complete) {
+    await plan.updateOne({ one_rm: update.complete ? plan.getOneRM() : 0 });
+  }
+};

--- a/src/models/types/Plan.ts
+++ b/src/models/types/Plan.ts
@@ -2,12 +2,20 @@ import { DocumentType } from '@typegoose/typegoose';
 import { Plan } from '@src/models/Plan';
 import { User } from '@src/models/User';
 import { UserQueryHelpers } from '@src/models/types/User';
+import { WeightSet } from '@src/models/types/WeightSet';
 
 export interface PlanMethods {
   checkPermission: (
     this: DocumentType<Plan, PlanQueryHelpers>,
     user: DocumentType<User, UserQueryHelpers>,
   ) => DocumentType<Plan>;
+
+  hasWeightSets: (
+    this: DocumentType<Plan, PlanQueryHelpers>,
+    sets: Plan['sets'],
+  ) => sets is WeightSet[];
+
+  getOneRM: (this: DocumentType<Plan, PlanQueryHelpers>) => number;
 }
 
 export interface PlanQueryHelpers {}

--- a/src/models/types/WeightSet.ts
+++ b/src/models/types/WeightSet.ts
@@ -1,0 +1,7 @@
+import { Set } from '@src/models/Set';
+
+export interface WeightSet extends Set {
+  count: number;
+
+  weight: number;
+}

--- a/tests/unit/plan.test.ts
+++ b/tests/unit/plan.test.ts
@@ -1,8 +1,65 @@
 import { Model } from '@src/models/Model';
-import { Plan } from '@src/models/Plan';
+import { Plan, PlanModel } from '@src/models/Plan';
+import { signIn } from '@tests/helpers';
+import { PlanFactory } from '@src/factories/PlanFactory';
+import { graphql } from '@tests/graphql';
 
 describe('운동계획 모델', () => {
+  const updatePlanMutation = `mutation updatePlan($_id: ObjectId!, $input: UpdatePlanInput!) { updatePlan(_id: $_id, input: $input) }`;
+
   it('Model을 상속받고 있다', () => {
     expect(Object.getPrototypeOf(Plan)).toEqual(Model);
+  });
+
+  it('complete 상태 값을 완료로 변경했을 때 1rm을 추가하는 훅이 있다', async () => {
+    const { user, token } = await signIn();
+    const plan = await PlanModel.create({
+      ...(await PlanFactory({ complete: false })),
+      user,
+      sets: [{ weight: 100, count: 5 }],
+    });
+
+    expect((await PlanModel.findById(plan._id))?.one_rm).toEqual(0);
+
+    const { errors } = await graphql(
+      updatePlanMutation,
+      {
+        _id: plan._id.toHexString(),
+        input: {
+          complete: true,
+        },
+      },
+      token,
+    );
+
+    expect(errors).toBeUndefined();
+    expect((await PlanModel.findById(plan._id))?.one_rm).toEqual(
+      plan.getOneRM(),
+    );
+  });
+
+  it('complete 상태가 true였던 운동계획을 false로 변경했을 때 1rm을 0으로 변경하는 훅이 있다', async () => {
+    const { user, token } = await signIn();
+    const weight = 150;
+    const count = 5;
+    const plan = await PlanModel.create({
+      ...(await PlanFactory({ complete: true })),
+      user,
+      sets: [{ weight, count }],
+      one_rm: weight + weight * count * 0.025,
+    });
+    const { errors } = await graphql(
+      updatePlanMutation,
+      {
+        _id: plan._id.toHexString(),
+        input: {
+          complete: false,
+        },
+      },
+      token,
+    );
+
+    expect(errors).toBeUndefined();
+    expect((await PlanModel.findById(plan._id))?.one_rm).toEqual(0);
   });
 });


### PR DESCRIPTION
### 작업 개요
`Plan` 모델에 최대 무게를 토글하는 훅 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `one_rm` 프로퍼티 `Float`으로 타입 변경
- `Plan` 모델
    - 메서드 추가
        - `hasWeightSets`: 해당 운동 계획이 중량 운동인지 확인
        - `getOneRM`: 해당 운동 계획의 최대 무게를 반환
    - 훅 추가
        - `complete`의 상태가 변경되었을 때 `one_rm` 프로퍼티 토글
- `weight`와 `count` 값이 `required`인 `WeightSet` 인터페이스 생성

resolve #89

