### PR TITLE
[feat] 오늘의 운동 쿼리 생성

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "graphql-type-json": "^0.3.2",
     "jsonwebtoken": "^8.5.1",
     "mailgen": "^2.0.15",
+    "moment": "^2.29.1",
     "mongoose": "^6.0.6",
     "nodemailer": "^6.6.3",
     "rand-token": "^1.0.1",

--- a/src/factories/PlanFactory.ts
+++ b/src/factories/PlanFactory.ts
@@ -13,7 +13,7 @@ export const PlanFactory: (
       training: (
         await TrainingModel.create(TrainingFactory())
       )._id.toHexString(),
-      planDate: faker.date.future().toISOString(),
+      plannedAt: faker.date.future().toISOString(),
       sets: [...Array(faker.datatype.number(10))].map(() => SetFactory()),
       complete: faker.datatype.boolean(),
     } as CreatePlanInput,

--- a/src/limits/PlanLimit.ts
+++ b/src/limits/PlanLimit.ts
@@ -1,5 +1,5 @@
 export const PlanLimit = {
-  planDate: {
+  plannedAt: {
     minDate: new Date(1900, 0, 1),
   },
   sets: {

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -40,7 +40,7 @@ export class Plan extends Model implements PlanMethods {
 
   @Field(() => Date, { description: '운동 날짜' })
   @prop({ type: Date, required: true })
-  planDate: string;
+  plannedAt: string;
 
   @Field(() => [Set], { description: '세트', defaultValue: [] })
   @prop({ type: [mongoose.Schema.Types.Mixed], default: [] })

--- a/src/resolvers/PlanResolver.ts
+++ b/src/resolvers/PlanResolver.ts
@@ -1,4 +1,5 @@
 import { DocumentType, mongoose } from '@typegoose/typegoose';
+import moment from 'moment';
 import {
   Arg,
   Ctx,
@@ -37,6 +38,24 @@ export class PlanResolver implements ResolverInterface<Plan> {
     }
 
     return PlanModel.find({ user: user._id });
+  }
+
+  @Query(() => [Plan], { description: '사용자의 오늘의 운동 계획 조회' })
+  @UseMiddleware(AuthenticateMiddleware)
+  async todayPlans(
+    @Ctx() { user }: Context,
+  ): Promise<DocumentType<Plan, PlanQueryHelpers>[]> {
+    if (!user) {
+      throw new AuthenticationError();
+    }
+
+    return PlanModel.find({
+      user: user._id,
+      plannedAt: {
+        $gte: moment().startOf('day').toISOString(),
+        $lte: moment().endOf('day').toISOString(),
+      },
+    });
   }
 
   @Query(() => Number, { description: '최대 무게' })

--- a/src/resolvers/types/CreatePlanInput.ts
+++ b/src/resolvers/types/CreatePlanInput.ts
@@ -13,8 +13,8 @@ export class CreatePlanInput implements Partial<Plan> {
 
   @Field(() => Date, { description: '운동 날짜' })
   @IsDate()
-  @MinDate(PlanLimit.planDate.minDate)
-  planDate: string;
+  @MinDate(PlanLimit.plannedAt.minDate)
+  plannedAt: string;
 
   @Field(() => [SetInput], { description: '세트', nullable: true })
   @ValidateNested()

--- a/src/resolvers/types/UpdatePlanInput.ts
+++ b/src/resolvers/types/UpdatePlanInput.ts
@@ -13,8 +13,8 @@ export class UpdatePlanInput implements Partial<Plan> {
 
   @Field(() => Date, { description: '운동 날짜', nullable: true })
   @IsDate()
-  @MinDate(PlanLimit.planDate.minDate)
-  planDate?: string;
+  @MinDate(PlanLimit.plannedAt.minDate)
+  plannedAt?: string;
 
   @Field(() => [SetInput], { description: '세트', nullable: true })
   @ValidateNested()

--- a/tests/feature/create-plans.test.ts
+++ b/tests/feature/create-plans.test.ts
@@ -10,7 +10,7 @@ import { graphql } from '@tests/graphql';
 import { signIn } from '@tests/helpers';
 
 describe('운동 계획 생성', () => {
-  const createPlanMutation = `mutation createPlan($input: CreatePlanInput!) { createPlan(input: $input) { _id, user { _id, name }, training { _id, name }, planDate, sets { count, weight } } }`;
+  const createPlanMutation = `mutation createPlan($input: CreatePlanInput!) { createPlan(input: $input) { _id, user { _id, name }, training { _id, name }, plannedAt, sets { count, weight } } }`;
 
   it('로그인 하지 않은 사용자는 요청할 수 없다', async () => {
     const { errors } = await graphql(createPlanMutation, {
@@ -37,7 +37,7 @@ describe('운동 계획 생성', () => {
     expect(data?.createPlan).toHaveProperty('_id');
     expect(data?.createPlan).toHaveProperty(['user', '_id']);
     expect(data?.createPlan).toHaveProperty(['training', '_id']);
-    expect(data?.createPlan).toHaveProperty('planDate');
+    expect(data?.createPlan).toHaveProperty('plannedAt');
     expect(data?.createPlan).toHaveProperty('sets');
   });
 
@@ -91,7 +91,7 @@ describe('운동 계획 생성', () => {
     const { errors } = await graphql(
       createPlanMutation,
       {
-        input: await PlanFactory({ planDate: '' }),
+        input: await PlanFactory({ plannedAt: '' }),
       },
       token,
     );
@@ -103,16 +103,16 @@ describe('운동 계획 생성', () => {
     }
   });
 
-  it(`운동 날짜는 ${PlanLimit.planDate.minDate.getFullYear()}년 이상 이하이어야 한다`, async () => {
+  it(`운동 날짜는 ${PlanLimit.plannedAt.minDate.getFullYear()}년 이상 이하이어야 한다`, async () => {
     const { token } = await signIn();
-    const planDate = new Date(PlanLimit.planDate.minDate);
-    planDate.setDate(planDate.getDate() - 1);
+    const plannedAt = new Date(PlanLimit.plannedAt.minDate);
+    plannedAt.setDate(plannedAt.getDate() - 1);
 
     const { errors } = await graphql(
       createPlanMutation,
       {
         input: await PlanFactory({
-          planDate: planDate.toISOString(),
+          plannedAt: plannedAt.toISOString(),
         }),
       },
       token,

--- a/tests/feature/update-plans.test.ts
+++ b/tests/feature/update-plans.test.ts
@@ -62,7 +62,7 @@ describe('운동 계획 수정', () => {
       {
         _id: plan._id.toHexString(),
         input: await PlanFactory({
-          planDate: updatePlanDate.toISOString(),
+          plannedAt: updatePlanDate.toISOString(),
         }),
       },
       token,
@@ -75,7 +75,7 @@ describe('운동 계획 수정', () => {
         await PlanModel.findById(plan._id)
           .orFail(new DocumentNotFoundError())
           .exec()
-      ).planDate,
+      ).plannedAt,
     ).toEqual(updatePlanDate);
   });
 
@@ -88,7 +88,7 @@ describe('운동 계획 수정', () => {
       {
         _id: plan._id.toHexString(),
         input: await PlanFactory({
-          planDate: updatePlanDate.toISOString(),
+          plannedAt: updatePlanDate.toISOString(),
         }),
       },
       token,
@@ -101,7 +101,7 @@ describe('운동 계획 수정', () => {
         await PlanModel.findById(plan._id)
           .orFail(new DocumentNotFoundError())
           .exec()
-      ).planDate,
+      ).plannedAt,
     ).toEqual(updatePlanDate);
   });
 
@@ -131,7 +131,7 @@ describe('운동 계획 수정', () => {
       updatePlanMutation,
       {
         _id: plan._id.toHexString(),
-        input: await PlanFactory({ planDate: '' }),
+        input: await PlanFactory({ plannedAt: '' }),
       },
       token,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4355,6 +4355,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 mongodb-connection-string-url@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mongodb-connection-string-url/-/mongodb-connection-string-url-2.0.0.tgz#72cea65084ffa45655670070efb57bb0a5da46bc"


### PR DESCRIPTION
### 작업 개요
오늘의 운동 쿼리 생성

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- 오늘의 운동인지 확인하기 위해 [momentjs](https://momentjs.com/) 설치
- `Plan` 모델의 `planDate` -> `plannedAt` 으로 변경
    - 관련 테스트 수정
- 해당 사용자의 오늘의 운동 계획들을 반환하는 `todayPlans` 쿼리 생성
    - 관련 테스트 작성

### 생각해볼 문제
`plans` 쿼리를 이용한 다음 클라이언트에서 `filter`해서 사용할 수도 있다. 하지만 오늘의 운동 계획은 모든 운동 계획 페이지에서 오늘 날짜의 운동을 수정했을 때 홈쪽에서의 오늘의 운동 계획도 변경되어야하기 때문에 `recoil`로 전역 상태 관리를 할 가능성이 크다. `recoil`의 `default` 데이터를 넣기 위해선 `RecoilProvider`에서 오늘의 운동 계획들을 불러어 하는데 앱을 실행할 때마다 모든 운동 계획들을 전부다 가져오는건 리소스 낭비라고 생각한다.

resolve #111

