### PR TITLE
[fix] Model에 createdAt updatedAt 프로퍼티 추가

### DIFF
--- a/src/models/Model.ts
+++ b/src/models/Model.ts
@@ -1,8 +1,17 @@
-import { mongoose } from '@typegoose/typegoose';
+import { modelOptions, mongoose } from '@typegoose/typegoose';
 import { Field, ID, InterfaceType } from 'type-graphql';
 
 @InterfaceType()
+@modelOptions({
+  schemaOptions: { timestamps: true },
+})
 export abstract class Model {
   @Field(() => ID)
   readonly _id: mongoose.Types.ObjectId;
+
+  @Field(() => Date)
+  readonly createdAt: Date;
+
+  @Field(() => Date)
+  readonly updatedAt: Date;
 }

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -25,10 +25,7 @@ import { WeightSet } from './types/WeightSet';
 
 @pre<Plan>('save', setOneRM)
 @ObjectType({ implements: Model, description: '운동계획 모델' })
-@modelOptions({
-  options: { allowMixed: Severity.ALLOW },
-  schemaOptions: { timestamps: true },
-})
+@modelOptions({ options: { allowMixed: Severity.ALLOW } })
 export class Plan extends Model implements PlanMethods {
   @Field(() => User, { description: '사용자' })
   @prop({ ref: 'User', required: true })

--- a/src/models/Training.ts
+++ b/src/models/Training.ts
@@ -1,9 +1,4 @@
-import {
-  getModelForClass,
-  modelOptions,
-  pre,
-  prop,
-} from '@typegoose/typegoose';
+import { getModelForClass, pre, prop } from '@typegoose/typegoose';
 import { Field, Int, ObjectType } from 'type-graphql';
 
 import { TrainingType } from '@src/types/enums';
@@ -17,7 +12,6 @@ import { TrainingMethods, TrainingQueryHelpers } from './types/Training';
   deleteLinkedReferences,
 )
 @ObjectType({ implements: Model, description: '운동종목 모델' })
-@modelOptions({ schemaOptions: { timestamps: true } })
 export class Training extends Model implements TrainingMethods {
   @Field(() => String, { description: '이름' })
   @prop({ type: String, required: true, unique: true })

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -23,10 +23,7 @@ import { UserMethods, UserQueryHelpers } from './types/User';
   deleteLinkedReferences,
 )
 @ObjectType({ implements: Model, description: '사용자 모델' })
-@modelOptions({
-  options: { allowMixed: Severity.ALLOW },
-  schemaOptions: { timestamps: true },
-})
+@modelOptions({ options: { allowMixed: Severity.ALLOW } })
 export class User extends Model implements UserMethods {
   @Field(() => String, { description: '이름' })
   @prop({ type: String, required: true })


### PR DESCRIPTION
### 작업 개요
`Model`에 `createdAt`, `updatedAt` 프로퍼티 추가 및 `timestamps` 옵션 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [x] 프로젝트 구조 변경

### 작업 상세 내용
- `Model`에 `createdAt`, `updatedAt` 프로퍼티 추가
- `Model`에 `timestamps` `schmeOption` 추가
- `User`, `Training`, `Plan` 모델에 `timestamps` 옵션 제거

resolve #116

