### PR TITLE
[feat] 중량운동, 맨몸운동, 유산소운동 구분

### DIFF
--- a/src/factories/TrainingFactory.ts
+++ b/src/factories/TrainingFactory.ts
@@ -2,7 +2,7 @@ import faker from 'faker';
 
 import { TrainingLimit } from '@src/limits/TrainingLimit';
 import { CreateTrainingInput } from '@src/resolvers/types/CreateTrainingInput';
-import { TrainingType } from '@src/types/enums';
+import { TrainingCategory, TrainingType } from '@src/types/enums';
 
 export const TrainingFactory: (
   input?: Partial<CreateTrainingInput>,
@@ -10,6 +10,11 @@ export const TrainingFactory: (
   Object.assign(
     {
       name: faker.unique(faker.name.lastName),
+      category: faker.random.arrayElement([
+        TrainingCategory.WEIGHT,
+        TrainingCategory.CARDIOVASCULAR,
+        TrainingCategory.CALISTHENICS,
+      ]),
       type: faker.random.arrayElement([
         TrainingType.LOWER,
         TrainingType.CHEST,

--- a/src/models/Training.ts
+++ b/src/models/Training.ts
@@ -1,7 +1,7 @@
 import { getModelForClass, pre, prop } from '@typegoose/typegoose';
 import { Field, Int, ObjectType } from 'type-graphql';
 
-import { TrainingType } from '@src/types/enums';
+import { TrainingCategory, TrainingType } from '@src/types/enums';
 
 import { Model } from './Model';
 import { deleteLinkedReferences } from './hooks/training-hooks';
@@ -16,6 +16,10 @@ export class Training extends Model implements TrainingMethods {
   @Field(() => String, { description: '이름' })
   @prop({ type: String, required: true, unique: true })
   name: string;
+
+  @Field(() => TrainingCategory, { description: '분류' })
+  @prop({ enum: TrainingCategory, type: String, required: true })
+  category: TrainingCategory;
 
   @Field(() => TrainingType, { description: '종류' })
   @prop({ enum: TrainingType, type: String, required: true })

--- a/src/resolvers/types/CreateTrainingInput.ts
+++ b/src/resolvers/types/CreateTrainingInput.ts
@@ -2,13 +2,16 @@ import { IsNotEmpty, IsUrl, Max, Min } from 'class-validator';
 import { Field, InputType, Int } from 'type-graphql';
 
 import { Training } from '@src/models/Training';
-import { TrainingType } from '@src/types/enums';
+import { TrainingCategory, TrainingType } from '@src/types/enums';
 
 @InputType({ description: '운동종목 추가 입력 객체' })
 export class CreateTrainingInput implements Partial<Training> {
   @Field(() => String, { description: '이름' })
   @IsNotEmpty()
   name: string;
+
+  @Field(() => TrainingCategory, { description: '분류' })
+  category: TrainingCategory;
 
   @Field(() => TrainingType, { description: '종류' })
   type: TrainingType;

--- a/src/resolvers/types/UpdateTrainingInput.ts
+++ b/src/resolvers/types/UpdateTrainingInput.ts
@@ -2,13 +2,16 @@ import { IsNotEmpty, IsUrl, Max, Min } from 'class-validator';
 import { Field, InputType, Int } from 'type-graphql';
 
 import { Training } from '@src/models/Training';
-import { TrainingType } from '@src/types/enums';
+import { TrainingCategory, TrainingType } from '@src/types/enums';
 
 @InputType({ description: '운동종목 추가 입력 객체' })
 export class UpdateTrainingInput implements Partial<Training> {
   @Field(() => String, { description: '이름', nullable: true })
   @IsNotEmpty()
   name?: string;
+
+  @Field(() => TrainingCategory, { description: '분류', nullable: true })
+  category?: TrainingCategory;
 
   @Field(() => TrainingType, { description: '종류', nullable: true })
   type?: TrainingType;

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -7,6 +7,16 @@ export enum Gender {
 }
 registerEnumType(Gender, { name: 'Gender', description: '성별' });
 
+export enum TrainingCategory {
+  WEIGHT = 'WEIGHT', // 중량 운동
+  CALISTHENICS = 'CALISTHENICS', // 맨몸 운동
+  CARDIOVASCULAR = 'CARDIOVASCULAR', // 유산소
+}
+registerEnumType(TrainingCategory, {
+  name: 'TrainingCategory',
+  description: '운동분류',
+});
+
 export enum TrainingType {
   LOWER = 'LOWER', // 하체
   CHEST = 'CHEST', // 가슴

--- a/tests/feature/create-training.test.ts
+++ b/tests/feature/create-training.test.ts
@@ -92,6 +92,25 @@ describe('운동종목 추가', () => {
     }
   });
 
+  it('분류 필드는 반드시 필요하다', async () => {
+    const { token } = await signIn(undefined, [Role.ADMIN]);
+    const { errors } = await graphql(
+      createTrainingMutation,
+      {
+        input: TrainingFactory({
+          category: undefined,
+        }),
+      },
+      token,
+    );
+
+    expect(errors).toBeDefined();
+    if (errors) {
+      expect(errors.length).toEqual(1);
+      expect(errors[0]).toBeInstanceOf(GraphQLError);
+    }
+  });
+
   it('종류 필드는 반드시 필요하다', async () => {
     const { token } = await signIn(undefined, [Role.ADMIN]);
     const { errors } = await graphql(


### PR DESCRIPTION
### 작업 개요
중량운동, 맨몸운동, 유산소운동 등을 구분할 수 있도록 `Training`모델에 `category` 프로퍼티를 추가합니다.

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `TrainingCategory` `enum` 추가
- `Training`, `TrainingFactory`, `CreateTrainingInput`, `UpdateTrainingInput`에 `category` 프로퍼티 추가
    - 관련 테스트 수정 및 추가

### 생각해볼 문제
`Training`의 `category`에 따라 다이나믹한 `Volumn` 프로퍼티들을 불러올 수 있을것인가...!

resolve #120

