### PR TITLE
[feat] Volume모델의 training, complete, oneRM Plan모델로 이동

### DIFF
--- a/src/factories/PlanFactory.ts
+++ b/src/factories/PlanFactory.ts
@@ -1,6 +1,8 @@
 import faker from 'faker';
 
+import { TrainingFactory } from '@src/factories/TrainingFactory';
 import { VolumeFactory } from '@src/factories/VolumeFactory';
+import { TrainingModel } from '@src/models/Training';
 import { CreatePlanInput } from '@src/resolvers/types/CreatePlanInput';
 
 export const PlanFactory: (
@@ -9,9 +11,11 @@ export const PlanFactory: (
   Object.assign(
     {
       plannedAt: faker.date.future().toISOString(),
-      volumes: await Promise.all(
-        [...Array(faker.datatype.number(10))].map(() => VolumeFactory()),
-      ),
+      training: (
+        await TrainingModel.create(TrainingFactory())
+      )._id.toHexString(),
+      complete: faker.datatype.boolean(),
+      volumes: [...Array(faker.datatype.number(10))].map(() => VolumeFactory()),
     } as CreatePlanInput,
     input,
   );

--- a/src/factories/VolumeFactory.ts
+++ b/src/factories/VolumeFactory.ts
@@ -1,40 +1,30 @@
-import { DocumentType } from '@typegoose/typegoose';
 import faker from 'faker';
 
-import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
-import { TrainingFactory } from '@src/factories/TrainingFactory';
-import { Training, TrainingModel } from '@src/models/Training';
-import { TrainingQueryHelpers } from '@src/models/types/Training';
 import { VolumeInput } from '@src/resolvers/types/VolumeInput';
 import { TrainingCategory } from '@src/types/enums';
 
-export const VolumeFactory: (
-  input?: Partial<VolumeInput>,
-) => Promise<VolumeInput> = async input => {
-  const training: DocumentType<Training, TrainingQueryHelpers> = input?.training
-    ? await TrainingModel.findById(input.training)
-        .orFail(new DocumentNotFoundError())
-        .exec()
-    : await TrainingModel.create(TrainingFactory());
+export const VolumeFactory: (input?: Partial<VolumeInput>) => VolumeInput =
+  input => {
+    const randomCategory = faker.random.arrayElement([
+      TrainingCategory.WEIGHT,
+      TrainingCategory.CARDIOVASCULAR,
+      TrainingCategory.CALISTHENICS,
+    ]);
 
-  return Object.assign(
-    {
-      training: training._id.toHexString(),
-      complete: faker.datatype.boolean(),
-    },
-    training.category === TrainingCategory.WEIGHT
-      ? {
-          count: faker.datatype.number(),
-          weight: faker.datatype.float(2),
-        }
-      : training.category === TrainingCategory.CALISTHENICS
-      ? {
-          count: faker.datatype.number(),
-        }
-      : {
-          times: faker.datatype.float(2),
-          distances: faker.datatype.float(2),
-        },
-    input,
-  );
-};
+    return Object.assign(
+      randomCategory === TrainingCategory.WEIGHT
+        ? {
+            count: faker.datatype.number(),
+            weight: faker.datatype.float(2),
+          }
+        : randomCategory === TrainingCategory.CALISTHENICS
+        ? {
+            count: faker.datatype.number(),
+          }
+        : {
+            times: faker.datatype.float(2),
+            distances: faker.datatype.float(2),
+          },
+      input,
+    );
+  };

--- a/src/models/Volume.ts
+++ b/src/models/Volume.ts
@@ -5,28 +5,16 @@ import { CalisthenicsVolume } from './CalisthenicsVolume';
 import { CardiovascularVolume } from './CardiovascularVolume';
 import { Model } from './Model';
 import { Plan } from './Plan';
-import { Training } from './Training';
 import { WeightVolume } from './WeightVolume';
-import { setOneRM } from './hooks/volume-hooks';
+import { setTotal } from './hooks/volume-hooks';
 import { VolumeMethods, VolumeQueryHelpers } from './types/Volume';
 
-@pre<Volume>('save', setOneRM)
+@pre<Volume>('save', setTotal)
 @ObjectType({ implements: Model, description: '운동 볼륨' })
 export class Volume extends Model implements VolumeMethods {
   @Field(() => Plan, { description: '운동계획' })
   @prop({ ref: 'Plan', required: true })
   plan: Ref<Plan>;
-
-  @Field(() => Training, { description: '운동종목' })
-  @prop({ ref: 'Training', required: true })
-  training: Ref<Training, string>;
-
-  @Field(() => Boolean, {
-    description: '완료 여부',
-    defaultValue: false,
-  })
-  @prop({ type: Boolean, default: false })
-  complete: boolean;
 
   @Field(() => Int, { description: '횟수', nullable: true })
   @prop({ type: Number })
@@ -45,12 +33,7 @@ export class Volume extends Model implements VolumeMethods {
   distances?: number;
 
   @Field(() => Float, { description: '총 볼륨', defaultValue: 0 })
-  @prop({ type: Number, default: 0 })
   total: number;
-
-  @Field(() => Float, { description: '1rm', defaultValue: 0 })
-  @prop({ type: Number, default: 0 })
-  oneRM: number;
 
   isCalisthenicsVolume(): this is CalisthenicsVolume {
     return (

--- a/src/models/WeightVolume.ts
+++ b/src/models/WeightVolume.ts
@@ -1,4 +1,3 @@
-import { prop } from '@typegoose/typegoose';
 import { Field, Float, Int, InterfaceType } from 'type-graphql';
 
 import { Volume } from './Volume';
@@ -11,10 +10,6 @@ export class WeightVolume extends Volume {
   @Field(() => Float, { description: '무게(kg)' })
   weight: number;
 
-  @Field(() => Float, { description: '총 볼륨' })
+  @Field(() => Float, { description: '총 볼륨', defaultValue: 0 })
   total: number;
-
-  @Field(() => Float, { description: '1rm', defaultValue: 0 })
-  @prop({ type: Number, default: 0 })
-  oneRM: number;
 }

--- a/src/models/hooks/plan-hooks.ts
+++ b/src/models/hooks/plan-hooks.ts
@@ -1,7 +1,27 @@
-import { PreFnWithQuery } from '@src/types/hooks';
+import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
+import { PreFnWithDocumentType, PreFnWithQuery } from '@src/types/hooks';
 
 import { Plan } from '../Plan';
 import { VolumeModel } from '../Volume';
+import { WeightVolume } from '../WeightVolume';
+
+export const setOneRM: PreFnWithDocumentType<Plan> = async function () {
+  const volume = (
+    (
+      await Promise.all(
+        this.volumes.map(volume =>
+          VolumeModel.findById(volume)
+            .orFail(new DocumentNotFoundError())
+            .exec(),
+        ),
+      )
+    ).filter(volume => volume.isWeightVolume()) as WeightVolume[]
+  ).sort((a, b) => b.weight * b.count - a.weight * a.count)[0];
+
+  this.oneRM = volume
+    ? volume.weight + volume.weight * volume.count * 0.025
+    : 0;
+};
 
 export const deleteLinkedReferences: PreFnWithQuery<Plan> = async function () {
   await VolumeModel.deleteMany({ plan: this.getFilter()._id });

--- a/src/models/hooks/training-hooks.ts
+++ b/src/models/hooks/training-hooks.ts
@@ -1,11 +1,11 @@
 import { PreFnWithQuery } from '@src/types/hooks';
 
+import { PlanModel } from '../Plan';
 import { Training } from '../Training';
-import { VolumeModel } from '../Volume';
 
 export const deleteLinkedReferences: PreFnWithQuery<Training> =
   async function () {
-    await VolumeModel.deleteMany({
+    await PlanModel.deleteMany({
       training: this.getFilter()._id?.toString(),
     });
   };

--- a/src/models/hooks/volume-hooks.ts
+++ b/src/models/hooks/volume-hooks.ts
@@ -1,14 +1,6 @@
-import { round } from 'lodash';
-
+import { Volume } from '@src/models/Volume';
 import { PreFnWithDocumentType } from '@src/types/hooks';
 
-import { Volume } from '../Volume';
-
-export const setOneRM: PreFnWithDocumentType<Volume> = function () {
-  if (this.isWeightVolume()) {
-    const { weight, count } = this;
-
-    this.total = weight * count;
-    this.oneRM = round(weight + weight * count * 0.025, 1);
-  }
+export const setTotal: PreFnWithDocumentType<Volume> = async function () {
+  this.total = this.isWeightVolume() ? this.weight * this.count : 0;
 };

--- a/src/resolvers/VolumeResolver.ts
+++ b/src/resolvers/VolumeResolver.ts
@@ -1,71 +1,18 @@
 import { DocumentType } from '@typegoose/typegoose';
-import {
-  Arg,
-  Ctx,
-  FieldResolver,
-  Query,
-  Resolver,
-  ResolverInterface,
-  Root,
-  UseMiddleware,
-} from 'type-graphql';
+import { FieldResolver, Resolver, ResolverInterface, Root } from 'type-graphql';
 
-import { Context } from '@src/context';
-import AuthenticationError from '@src/errors/AuthenticationError';
 import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
-import { AuthenticateMiddleware } from '@src/middlewares/AuthenticateMiddleware';
 import { Plan, PlanModel } from '@src/models/Plan';
-import { Training, TrainingModel } from '@src/models/Training';
-import { Volume, VolumeModel } from '@src/models/Volume';
+import { Volume } from '@src/models/Volume';
 import { PlanQueryHelpers } from '@src/models/types/Plan';
-import { TrainingQueryHelpers } from '@src/models/types/Training';
 
 @Resolver(() => Volume)
 export class VolumeResolver implements ResolverInterface<Volume> {
-  @Query(() => Number, { description: '최대 무게' })
-  @UseMiddleware(AuthenticateMiddleware)
-  async getOneRM(
-    @Arg('name') name: string,
-    @Ctx() { user }: Context,
-  ): Promise<number> {
-    if (!user) {
-      throw new AuthenticationError();
-    }
-
-    const planIDs = (await PlanModel.find({ user: user._id })).map(
-      plan => plan._id,
-    );
-    const training = await TrainingModel.findOne({ name });
-
-    if (planIDs.length === 0 || training === null) {
-      return 0;
-    }
-
-    return (
-      (
-        await VolumeModel.findOne({
-          plan: { $in: planIDs },
-          training: training._id.toHexString(),
-          complete: true,
-        }).sort({ oneRM: -1 })
-      )?.oneRM || 0
-    );
-  }
-
   @FieldResolver()
   async plan(
     @Root() volume: Volume,
   ): Promise<DocumentType<Plan, PlanQueryHelpers>> {
     return await PlanModel.findById(volume.plan)
-      .orFail(new DocumentNotFoundError())
-      .exec();
-  }
-
-  @FieldResolver()
-  async training(
-    @Root() volume: Volume,
-  ): Promise<DocumentType<Training, TrainingQueryHelpers>> {
-    return await TrainingModel.findById(volume.training)
       .orFail(new DocumentNotFoundError())
       .exec();
   }

--- a/src/resolvers/types/CreatePlanInput.ts
+++ b/src/resolvers/types/CreatePlanInput.ts
@@ -1,5 +1,5 @@
-import { IsDate, MinDate, ValidateNested } from 'class-validator';
-import { Field, InputType } from 'type-graphql';
+import { IsBoolean, IsDate, MinDate, ValidateNested } from 'class-validator';
+import { Field, ID, InputType } from 'type-graphql';
 
 import { PlanLimit } from '@src/limits/PlanLimit';
 
@@ -11,6 +11,13 @@ export class CreatePlanInput {
   @IsDate()
   @MinDate(PlanLimit.plannedAt.minDate)
   plannedAt: string;
+
+  @Field(() => ID, { description: '운동종목' })
+  training: string;
+
+  @Field(() => Boolean, { description: '완료 여부', nullable: true })
+  @IsBoolean()
+  complete?: boolean;
 
   @Field(() => [VolumeInput], { description: '볼륨' })
   @ValidateNested()

--- a/src/resolvers/types/UpdatePlanInput.ts
+++ b/src/resolvers/types/UpdatePlanInput.ts
@@ -1,5 +1,5 @@
-import { IsDate, MinDate, ValidateNested } from 'class-validator';
-import { Field, InputType } from 'type-graphql';
+import { IsBoolean, IsDate, MinDate, ValidateNested } from 'class-validator';
+import { Field, ID, InputType } from 'type-graphql';
 
 import { PlanLimit } from '@src/limits/PlanLimit';
 
@@ -11,6 +11,13 @@ export class UpdatePlanInput {
   @IsDate()
   @MinDate(PlanLimit.plannedAt.minDate)
   plannedAt?: string;
+
+  @Field(() => ID, { description: '운동종목', nullable: true })
+  training?: string;
+
+  @Field(() => Boolean, { description: '완료 여부', nullable: true })
+  @IsBoolean()
+  complete?: boolean;
 
   @Field(() => [VolumeInput], { description: '볼륨', nullable: true })
   @ValidateNested()

--- a/src/resolvers/types/VolumeInput.ts
+++ b/src/resolvers/types/VolumeInput.ts
@@ -1,5 +1,5 @@
 import { mongoose } from '@typegoose/typegoose';
-import { IsBoolean, Min } from 'class-validator';
+import { Min } from 'class-validator';
 import { Field, Float, ID, InputType, Int } from 'type-graphql';
 
 import { VolumeLimit } from '@src/limits/VolumeLimit';
@@ -9,13 +9,6 @@ import { Volume } from '@src/models/Volume';
 export class VolumeInput implements Partial<Volume> {
   @Field(() => ID, { nullable: true })
   readonly _id?: mongoose.Types.ObjectId;
-
-  @Field(() => ID, { description: '운동종목' })
-  training: string;
-
-  @Field(() => Boolean, { description: '완료 여부', nullable: true })
-  @IsBoolean()
-  complete?: boolean;
 
   @Field(() => Int, { description: '횟수', nullable: true })
   @Min(VolumeLimit.count.min)

--- a/tests/feature/create-plans.test.ts
+++ b/tests/feature/create-plans.test.ts
@@ -11,7 +11,7 @@ import { TrainingModel } from '@src/models/Training';
 import { graphql } from '@tests/graphql';
 import { signIn } from '@tests/helpers';
 
-const createPlanMutation = `mutation createPlan($input: CreatePlanInput!) { createPlan(input: $input) { _id, user { _id, name }, plannedAt, volumes { training { _id, name }, count, weight } } }`;
+const createPlanMutation = `mutation createPlan($input: CreatePlanInput!) { createPlan(input: $input) { _id, user { _id, name }, plannedAt, training { _id, name }, complete, volumes { count, weight } } }`;
 
 describe('운동 계획 생성', () => {
   it('로그인 하지 않은 사용자는 요청할 수 없다', async () => {
@@ -100,9 +100,7 @@ describe('운동 볼륨 생성', () => {
     const { errors } = await graphql(
       createPlanMutation,
       {
-        input: await PlanFactory({
-          volumes: [await VolumeFactory({ training: undefined })],
-        }),
+        input: await PlanFactory({ training: undefined }),
       },
       token,
     );
@@ -120,21 +118,13 @@ describe('운동 볼륨 생성', () => {
     const { data, errors } = await graphql(
       createPlanMutation,
       {
-        input: await PlanFactory({
-          volumes: [
-            await VolumeFactory({
-              training: training._id.toHexString(),
-            }),
-          ],
-        }),
+        input: await PlanFactory({ training: training._id.toHexString() }),
       },
       token,
     );
 
     expect(errors).toBeUndefined();
-    expect(
-      training.name === data?.createPlan.volumes[0].training.name,
-    ).toBeTruthy();
+    expect(training.name === data?.createPlan.training.name).toBeTruthy();
   });
 
   it('완료 여부는 빈 값을 허용하고 default가 false이다', async () => {
@@ -143,15 +133,13 @@ describe('운동 볼륨 생성', () => {
     const { data, errors } = await graphql(
       createPlanMutation,
       {
-        input: await PlanFactory({
-          volumes: [await VolumeFactory({ complete: undefined })],
-        }),
+        input: await PlanFactory({ complete: undefined }),
       },
       token,
     );
 
     expect(errors).toBeUndefined();
-    expect(data?.createPlan.volumes[0].complete).toBeFalsy();
+    expect(data?.createPlan.complete === false).toBeTruthy();
   });
 
   it('볼륨의 횟수, 무게, 시간, 거리는 빈 값을 허용한다', async () => {
@@ -163,7 +151,7 @@ describe('운동 볼륨 생성', () => {
           createPlanMutation,
           {
             input: await PlanFactory({
-              volumes: [await VolumeFactory({ [field]: undefined })],
+              volumes: [VolumeFactory({ [field]: undefined })],
             }),
           },
           token,
@@ -183,7 +171,7 @@ describe('운동 볼륨 생성', () => {
           createPlanMutation,
           {
             input: await PlanFactory({
-              volumes: [await VolumeFactory({ [key]: min - 1 })],
+              volumes: [VolumeFactory({ [key]: min - 1 })],
             }),
           },
           token,

--- a/tests/feature/update-plans.test.ts
+++ b/tests/feature/update-plans.test.ts
@@ -114,9 +114,7 @@ describe('운동 계획 수정', () => {
       updatePlanMutation,
       {
         _id: plan._id.toHexString(),
-        input: await PlanFactory({
-          volumes: [await VolumeFactory({ training: undefined })],
-        }),
+        input: await PlanFactory({ training: undefined }),
       },
       token,
     );
@@ -154,9 +152,7 @@ describe('운동 계획 수정', () => {
     const plan = await PlanModel.createWithVolumes(
       user,
       await PlanFactory({
-        volumes: await Promise.all(
-          [...Array(count)].map(() => VolumeFactory()),
-        ),
+        volumes: [...Array(count)].map(() => VolumeFactory()),
       }),
     );
 
@@ -167,7 +163,7 @@ describe('운동 계획 수정', () => {
       {
         _id: plan._id.toHexString(),
         input: {
-          volumes: [await VolumeFactory()],
+          volumes: [VolumeFactory()],
         },
       },
       token,

--- a/tests/unit/training.test.ts
+++ b/tests/unit/training.test.ts
@@ -1,10 +1,8 @@
 import { PlanFactory } from '@src/factories/PlanFactory';
 import { TrainingFactory } from '@src/factories/TrainingFactory';
-import { VolumeFactory } from '@src/factories/VolumeFactory';
 import { Model } from '@src/models/Model';
 import { PlanModel } from '@src/models/Plan';
 import { Training, TrainingModel } from '@src/models/Training';
-import { VolumeModel } from '@src/models/Volume';
 import { signIn } from '@tests/helpers';
 
 describe('운동종목 모델', () => {
@@ -12,7 +10,7 @@ describe('운동종목 모델', () => {
     expect(Object.getPrototypeOf(Training)).toEqual(Model);
   });
 
-  it('운동종목을 삭제하면 해당 종목으로 추가된 모든 운동 볼륨들이 삭제된다', async () => {
+  it('운동종목을 삭제하면 해당 종목으로 추가된 모든 운동 계획들이 삭제된다', async () => {
     const count = 5;
     const { user } = await signIn();
     const training = await TrainingModel.create(TrainingFactory());
@@ -20,19 +18,15 @@ describe('운동종목 모델', () => {
       [...Array(count)].map(async () =>
         PlanModel.createWithVolumes(
           user,
-          await PlanFactory({
-            volumes: [
-              await VolumeFactory({ training: training._id.toHexString() }),
-            ],
-          }),
+          await PlanFactory({ training: training._id.toHexString() }),
         ),
       ),
     );
 
-    expect(await VolumeModel.find().count().exec()).toEqual(count);
+    expect(await PlanModel.count()).toEqual(count);
 
     await TrainingModel.findByIdAndDelete(training._id);
 
-    expect(await VolumeModel.find().count().exec()).toEqual(0);
+    expect(await PlanModel.count()).toEqual(0);
   });
 });


### PR DESCRIPTION
### 작업 개요
`Volume`모델의 `training`, `complete`, `oneRM` 속성을 `Plan`모델로 이동

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `training`, `complete`, `oneRM` 속성 이동
    - `VolumeFactory` -> `PlanFactory`
    - `Volume`모델 -> `Plan`모델
    - `VolumeResolver` -> `PlanResolver`
    - `VolumeInput` -> `CreatePlanInput`, `UpdatePlanInput`
- `setOneRM` 훅을 `Plan` 모델로 이동
- 운동 종목이 삭제 되었을 때 해당 종목의 운동 계획이 삭제되도록 `Training` 훅 변경
- 관련 테스트 수정

resolve #126

