### PR TITLE
[feat] trainings 쿼리 추가

### DIFF
--- a/src/resolvers/TrainingResolver.ts
+++ b/src/resolvers/TrainingResolver.ts
@@ -1,5 +1,5 @@
 import { DocumentType, mongoose } from '@typegoose/typegoose';
-import { Arg, Authorized, Mutation, Resolver } from 'type-graphql';
+import { Arg, Authorized, Mutation, Query, Resolver } from 'type-graphql';
 
 import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
 import { Training, TrainingModel } from '@src/models/Training';
@@ -11,6 +11,11 @@ import { UpdateTrainingInput } from './types/UpdateTrainingInput';
 
 @Resolver(() => Training)
 export class TrainingResolver {
+  @Query(() => [Training], { description: '운동종목 조회' })
+  async trainings(): Promise<DocumentType<Training, TrainingQueryHelpers>[]> {
+    return TrainingModel.find();
+  }
+
   @Mutation(() => Training, { description: '운동종목 추가' })
   @Authorized(Role.ADMIN)
   async createTraining(

--- a/src/resolvers/types/CreateTrainingInput.ts
+++ b/src/resolvers/types/CreateTrainingInput.ts
@@ -22,7 +22,7 @@ export class CreateTrainingInput implements Partial<Training> {
   @Field(() => Int, { description: '선호도', defaultValue: 1 })
   @Min(1)
   @Max(10)
-  preference?: number;
+  preference: number;
 
   @Field(() => String, { description: '썸네일 경로', nullable: true })
   @IsUrl()

--- a/tests/feature/get-trainings.test.ts
+++ b/tests/feature/get-trainings.test.ts
@@ -1,0 +1,24 @@
+import { TrainingFactory } from '@src/factories/TrainingFactory';
+import { TrainingModel } from '@src/models/Training';
+import { graphql } from '@tests/graphql';
+
+describe('운동 종목 조회', () => {
+  it('모든 운동 종목을 조회할 수 있다', async () => {
+    const count = 3;
+    await Promise.all(
+      [...Array(count)].map(() => TrainingModel.create(TrainingFactory())),
+    );
+    const { data, errors } = await graphql(
+      `
+        query trainings {
+          trainings {
+            _id
+          }
+        }
+      `,
+    );
+
+    expect(errors).toBeUndefined();
+    expect(data?.trainings.length).toEqual(count);
+  });
+});


### PR DESCRIPTION
### 작업 개요
모든 운동 종목을 조회할 수 있는 `trainings` 쿼리를 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
-  `TrainingResolver`내에 `trainings` 쿼리 추가
    - 관련 테스트 추가

resolve #128

