### PR TITLE
[feat] complete 속성 Volume 모델로 이동 및 getOneRM query 재디자인

### DIFF
--- a/src/factories/PlanFactory.ts
+++ b/src/factories/PlanFactory.ts
@@ -13,7 +13,6 @@ export const PlanFactory: (input?: Partial<PlanInput>) => Promise<PlanInput> =
         training: (
           await TrainingModel.create(TrainingFactory())
         )._id.toHexString(),
-        complete: faker.datatype.boolean(),
         volumes: [...Array(faker.datatype.number(10))].map(() =>
           VolumeFactory(),
         ),

--- a/src/factories/VolumeFactory.ts
+++ b/src/factories/VolumeFactory.ts
@@ -25,6 +25,9 @@ export const VolumeFactory: (input?: Partial<VolumeInput>) => VolumeInput =
             times: faker.datatype.float(2),
             distances: faker.datatype.float(2),
           },
+      {
+        complete: faker.datatype.boolean(),
+      },
       input,
     );
   };

--- a/src/models/Plan.ts
+++ b/src/models/Plan.ts
@@ -7,7 +7,7 @@ import {
   Ref,
   ReturnModelType,
 } from '@typegoose/typegoose';
-import { Field, Float, ObjectType } from 'type-graphql';
+import { Field, ObjectType } from 'type-graphql';
 
 import AuthenticationError from '@src/errors/AuthenticationError';
 import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
@@ -20,11 +20,10 @@ import { Model } from './Model';
 import { Training } from './Training';
 import { User } from './User';
 import { Volume, VolumeModel } from './Volume';
-import { deleteLinkedReferences, setOneRM } from './hooks/plan-hooks';
+import { deleteLinkedReferences } from './hooks/plan-hooks';
 import { PlanMethods, PlanQueryHelpers } from './types/Plan';
 import { UserQueryHelpers } from './types/User';
 
-@pre<Plan>('save', setOneRM)
 @pre<Plan>(
   ['deleteOne', 'deleteMany', 'findOneAndDelete'],
   deleteLinkedReferences,
@@ -43,20 +42,9 @@ export class Plan extends Model implements PlanMethods {
   @prop({ ref: 'Training', required: true })
   training: Ref<Training, string>;
 
-  @Field(() => Boolean, {
-    description: '완료 여부',
-    defaultValue: false,
-  })
-  @prop({ type: Boolean, default: false })
-  complete: boolean;
-
   @Field(() => [Volume], { description: '볼륨', defaultValue: [] })
   @prop({ ref: 'Volume', default: [] })
   volumes: Ref<Volume>[];
-
-  @Field(() => Float, { description: '1rm', defaultValue: 0 })
-  @prop({ type: Number, default: 0 })
-  oneRM: number;
 
   checkPermission(
     this: DocumentType<Plan, PlanQueryHelpers>,

--- a/src/models/Volume.ts
+++ b/src/models/Volume.ts
@@ -6,15 +6,22 @@ import { CardiovascularVolume } from './CardiovascularVolume';
 import { Model } from './Model';
 import { Plan } from './Plan';
 import { WeightVolume } from './WeightVolume';
-import { setTotal } from './hooks/volume-hooks';
+import { setOneRMWithTotal } from './hooks/volume-hooks';
 import { VolumeMethods, VolumeQueryHelpers } from './types/Volume';
 
-@pre<Volume>('save', setTotal)
+@pre<Volume>('save', setOneRMWithTotal)
 @ObjectType({ implements: Model, description: '운동 볼륨' })
 export class Volume extends Model implements VolumeMethods {
   @Field(() => Plan, { description: '운동계획' })
   @prop({ ref: 'Plan', required: true })
   plan: Ref<Plan>;
+
+  @Field(() => Boolean, {
+    description: '완료 여부',
+    defaultValue: false,
+  })
+  @prop({ type: Boolean, default: false })
+  complete: boolean;
 
   @Field(() => Int, { description: '횟수', nullable: true })
   @prop({ type: Number })
@@ -34,6 +41,10 @@ export class Volume extends Model implements VolumeMethods {
 
   @Field(() => Float, { description: '총 볼륨', defaultValue: 0 })
   total: number;
+
+  @Field(() => Float, { description: '1rm', defaultValue: 0 })
+  @prop({ type: Number, default: 0 })
+  oneRM: number;
 
   isCalisthenicsVolume(): this is CalisthenicsVolume {
     return (

--- a/src/models/hooks/plan-hooks.ts
+++ b/src/models/hooks/plan-hooks.ts
@@ -1,27 +1,7 @@
-import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
-import { PreFnWithDocumentType, PreFnWithQuery } from '@src/types/hooks';
+import { PreFnWithQuery } from '@src/types/hooks';
 
 import { Plan } from '../Plan';
 import { VolumeModel } from '../Volume';
-import { WeightVolume } from '../WeightVolume';
-
-export const setOneRM: PreFnWithDocumentType<Plan> = async function () {
-  const volume = (
-    (
-      await Promise.all(
-        this.volumes.map(volume =>
-          VolumeModel.findById(volume)
-            .orFail(new DocumentNotFoundError())
-            .exec(),
-        ),
-      )
-    ).filter(volume => volume.isWeightVolume()) as WeightVolume[]
-  ).sort((a, b) => b.weight * b.count - a.weight * a.count)[0];
-
-  this.oneRM = volume
-    ? volume.weight + volume.weight * volume.count * 0.025
-    : 0;
-};
 
 export const deleteLinkedReferences: PreFnWithQuery<Plan> = async function () {
   await VolumeModel.deleteMany({ plan: this.getFilter()._id });

--- a/src/models/hooks/volume-hooks.ts
+++ b/src/models/hooks/volume-hooks.ts
@@ -1,6 +1,11 @@
-import { Volume } from '@src/models/Volume';
 import { PreFnWithDocumentType } from '@src/types/hooks';
 
-export const setTotal: PreFnWithDocumentType<Volume> = async function () {
-  this.total = this.isWeightVolume() ? this.weight * this.count : 0;
-};
+import { Volume } from '../Volume';
+
+export const setOneRMWithTotal: PreFnWithDocumentType<Volume> =
+  async function () {
+    this.oneRM = this.isWeightVolume()
+      ? this.weight + this.weight * this.count * 0.025
+      : 0;
+    this.total = this.isWeightVolume() ? this.weight * this.count : 0;
+  };

--- a/src/resolvers/PlanResolver.ts
+++ b/src/resolvers/PlanResolver.ts
@@ -40,33 +40,6 @@ export class PlanResolver implements ResolverInterface<Plan> {
     return PlanModel.find({ user: user._id });
   }
 
-  @Query(() => Number, { description: '최대 무게' })
-  @UseMiddleware(AuthenticateMiddleware)
-  async getOneRM(
-    @Arg('name') name: string,
-    @Ctx() { user }: Context,
-  ): Promise<number> {
-    if (!user) {
-      throw new AuthenticationError();
-    }
-
-    const training = await TrainingModel.findOne({ name });
-
-    if (training === null) {
-      return 0;
-    }
-
-    return (
-      (
-        await PlanModel.findOne({
-          user: user._id,
-          training: training._id.toHexString(),
-          complete: true,
-        }).sort({ oneRM: -1 })
-      )?.oneRM || 0
-    );
-  }
-
   @Mutation(() => [Plan], { description: '여러개의 운동 계획 생성 및 수정' })
   @UseMiddleware(AuthenticateMiddleware)
   async multipleCreateOrUpdatePlans(

--- a/src/resolvers/VolumeResolver.ts
+++ b/src/resolvers/VolumeResolver.ts
@@ -1,13 +1,71 @@
 import { DocumentType } from '@typegoose/typegoose';
-import { FieldResolver, Resolver, ResolverInterface, Root } from 'type-graphql';
+import {
+  Arg,
+  Ctx,
+  FieldResolver,
+  Query,
+  Resolver,
+  ResolverInterface,
+  Root,
+  UseMiddleware,
+} from 'type-graphql';
 
+import { Context } from '@src/context';
+import AuthenticationError from '@src/errors/AuthenticationError';
 import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
+import { AuthenticateMiddleware } from '@src/middlewares/AuthenticateMiddleware';
 import { Plan, PlanModel } from '@src/models/Plan';
-import { Volume } from '@src/models/Volume';
+import { TrainingModel } from '@src/models/Training';
+import { Volume, VolumeModel } from '@src/models/Volume';
 import { PlanQueryHelpers } from '@src/models/types/Plan';
 
 @Resolver(() => Volume)
 export class VolumeResolver implements ResolverInterface<Volume> {
+  @Query(() => Number, { description: '최대 무게' })
+  @UseMiddleware(AuthenticateMiddleware)
+  async getOneRM(
+    @Arg('name') name: string,
+    @Ctx() { user }: Context,
+  ): Promise<number> {
+    if (!user) {
+      throw new AuthenticationError();
+    }
+
+    const training = await TrainingModel.findOne({ name });
+
+    if (training === null) {
+      return 0;
+    }
+
+    const plans = await PlanModel.find({
+      user: user._id,
+      training: training._id.toHexString(),
+    }).exec();
+
+    const volumes = await Promise.all(
+      plans.map(plan =>
+        Promise.all(
+          plan.volumes.map(volume =>
+            VolumeModel.findById(volume?._id)
+              .orFail(new DocumentNotFoundError())
+              .exec(),
+          ),
+        ),
+      ),
+    );
+
+    const completedVolumes = volumes.reduce(
+      (p, c) => p.concat(c.filter(volume => volume.complete)),
+      [],
+    );
+
+    if (!completedVolumes.length) {
+      return 0;
+    }
+
+    return completedVolumes.sort((a, b) => b.oneRM - a.oneRM)[0].oneRM;
+  }
+
   @FieldResolver()
   async plan(
     @Root() volume: Volume,

--- a/src/resolvers/types/PlanInput.ts
+++ b/src/resolvers/types/PlanInput.ts
@@ -1,5 +1,5 @@
 import { mongoose } from '@typegoose/typegoose';
-import { IsBoolean, IsDate, MinDate, ValidateNested } from 'class-validator';
+import { IsDate, MinDate, ValidateNested } from 'class-validator';
 import { Field, ID, InputType } from 'type-graphql';
 
 import { PlanLimit } from '@src/limits/PlanLimit';
@@ -18,10 +18,6 @@ export class PlanInput {
 
   @Field(() => ID, { description: '운동종목', nullable: true })
   training?: string;
-
-  @Field(() => Boolean, { description: '완료 여부', nullable: true })
-  @IsBoolean()
-  complete?: boolean;
 
   @Field(() => [VolumeInput], { description: '볼륨', nullable: true })
   @ValidateNested()

--- a/src/resolvers/types/VolumeInput.ts
+++ b/src/resolvers/types/VolumeInput.ts
@@ -1,5 +1,5 @@
 import { mongoose } from '@typegoose/typegoose';
-import { Min } from 'class-validator';
+import { IsBoolean, Min } from 'class-validator';
 import { Field, Float, ID, InputType, Int } from 'type-graphql';
 
 import { VolumeLimit } from '@src/limits/VolumeLimit';
@@ -9,6 +9,10 @@ import { Volume } from '@src/models/Volume';
 export class VolumeInput implements Partial<Volume> {
   @Field(() => ID, { nullable: true })
   readonly _id?: mongoose.Types.ObjectId;
+
+  @Field(() => Boolean, { description: '완료 여부', nullable: true })
+  @IsBoolean()
+  complete?: boolean;
 
   @Field(() => Int, { description: '횟수', nullable: true })
   @Min(VolumeLimit.count.min)

--- a/tests/feature/create-plans.test.ts
+++ b/tests/feature/create-plans.test.ts
@@ -9,7 +9,6 @@ import { PlanFactory } from '@src/factories/PlanFactory';
 import { UserFactory } from '@src/factories/UserFactory';
 import { VolumeFactory } from '@src/factories/VolumeFactory';
 import { PlanLimit } from '@src/limits/PlanLimit';
-import { VolumeLimit } from '@src/limits/VolumeLimit';
 import { Plan, PlanModel } from '@src/models/Plan';
 import { User, UserModel } from '@src/models/User';
 import { VolumeModel } from '@src/models/Volume';
@@ -20,9 +19,9 @@ import { Role } from '@src/types/enums';
 import { graphql } from '@tests/graphql';
 import { signIn } from '@tests/helpers';
 
-const multipleCreateOrUpdatePlansMutation = `mutation multipleCreateOrUpdatePlans($inputs: [PlanInput!]!) { multipleCreateOrUpdatePlans(inputs: $inputs) { _id, user { _id, name }, plannedAt, training { _id, name }, complete, volumes { count, weight } } }`;
-
 describe('여러 개의 운동 계획 생성 및 수정', () => {
+  const multipleCreateOrUpdatePlansMutation = `mutation multipleCreateOrUpdatePlans($inputs: [PlanInput!]!) { multipleCreateOrUpdatePlans(inputs: $inputs) { _id, user { _id, name }, plannedAt, training { _id, name }, volumes { complete, count, weight } } }`;
+
   it('로그인 하지 않은 사용자는 생성 및 수정 요청할 수 없다', async () => {
     const { errors } = await graphql(multipleCreateOrUpdatePlansMutation, {
       inputs: [await PlanFactory()],
@@ -207,73 +206,6 @@ describe('여러 개의 운동 계획 생성 및 수정', () => {
 
     expect(errors).toBeUndefined();
     expect(await VolumeModel.count()).toEqual(1);
-  });
-});
-
-describe('운동 볼륨 생성', () => {
-  it('완료 여부는 빈 값을 허용하고 default가 false이다', async () => {
-    const { token } = await signIn();
-
-    const { data, errors } = await graphql(
-      multipleCreateOrUpdatePlansMutation,
-      {
-        inputs: [await PlanFactory({ complete: undefined })],
-      },
-      token,
-    );
-
-    expect(errors).toBeUndefined();
-    expect(
-      data?.multipleCreateOrUpdatePlans[0].complete === false,
-    ).toBeTruthy();
-  });
-
-  it('볼륨의 횟수, 무게, 시간, 거리는 빈 값을 허용한다', async () => {
-    const { token } = await signIn();
-
-    await Promise.all(
-      ['count', 'weight', 'times', 'distances'].map(async field => {
-        const { errors } = await graphql(
-          multipleCreateOrUpdatePlansMutation,
-          {
-            inputs: [
-              await PlanFactory({
-                volumes: [VolumeFactory({ [field]: undefined })],
-              }),
-            ],
-          },
-          token,
-        );
-
-        expect(errors).toBeUndefined();
-      }),
-    );
-  });
-
-  it(`볼륨의 횟수는 ${VolumeLimit.count.min}개 이상, 무게는 ${VolumeLimit.weight.min}kg 이상, 시간은 ${VolumeLimit.times.min}초 이상, 거리는 ${VolumeLimit.distances.min}m 이상 이어야 한다`, async () => {
-    const { token } = await signIn();
-
-    await Promise.all(
-      Object.entries(VolumeLimit).map(async ([key, { min }]) => {
-        const { errors } = await graphql(
-          multipleCreateOrUpdatePlansMutation,
-          {
-            inputs: [
-              await PlanFactory({
-                volumes: [VolumeFactory({ [key]: min - 1 })],
-              }),
-            ],
-          },
-          token,
-        );
-
-        expect(errors).toBeDefined();
-        if (errors) {
-          expect(errors.length).toEqual(1);
-          expect(errors[0].originalError).toBeInstanceOf(ValidationError);
-        }
-      }),
-    );
   });
 });
 

--- a/tests/feature/create-volumes.test.ts
+++ b/tests/feature/create-volumes.test.ts
@@ -1,0 +1,79 @@
+import ValidationError from '@src/errors/ValidationError';
+import { PlanFactory } from '@src/factories/PlanFactory';
+import { VolumeFactory } from '@src/factories/VolumeFactory';
+import { VolumeLimit } from '@src/limits/VolumeLimit';
+import { graphql } from '@tests/graphql';
+import { signIn } from '@tests/helpers';
+
+describe('운동 볼륨 생성', () => {
+  const multipleCreateOrUpdatePlansMutation = `mutation multipleCreateOrUpdatePlans($inputs: [PlanInput!]!) { multipleCreateOrUpdatePlans(inputs: $inputs) { _id, user { _id, name }, plannedAt, training { _id, name }, volumes { complete, count, weight } } }`;
+
+  it('완료 여부는 빈 값을 허용하고 default가 false이다', async () => {
+    const { token } = await signIn();
+
+    const { data, errors } = await graphql(
+      multipleCreateOrUpdatePlansMutation,
+      {
+        inputs: [
+          await PlanFactory({
+            volumes: [VolumeFactory({ complete: undefined })],
+          }),
+        ],
+      },
+      token,
+    );
+
+    expect(errors).toBeUndefined();
+    expect(
+      data?.multipleCreateOrUpdatePlans[0].volumes[0].complete === false,
+    ).toBeTruthy();
+  });
+
+  it('볼륨의 횟수, 무게, 시간, 거리는 빈 값을 허용한다', async () => {
+    const { token } = await signIn();
+
+    await Promise.all(
+      ['count', 'weight', 'times', 'distances'].map(async field => {
+        const { errors } = await graphql(
+          multipleCreateOrUpdatePlansMutation,
+          {
+            inputs: [
+              await PlanFactory({
+                volumes: [VolumeFactory({ [field]: undefined })],
+              }),
+            ],
+          },
+          token,
+        );
+
+        expect(errors).toBeUndefined();
+      }),
+    );
+  });
+
+  it(`볼륨의 횟수는 ${VolumeLimit.count.min}개 이상, 무게는 ${VolumeLimit.weight.min}kg 이상, 시간은 ${VolumeLimit.times.min}초 이상, 거리는 ${VolumeLimit.distances.min}m 이상 이어야 한다`, async () => {
+    const { token } = await signIn();
+
+    await Promise.all(
+      Object.entries(VolumeLimit).map(async ([key, { min }]) => {
+        const { errors } = await graphql(
+          multipleCreateOrUpdatePlansMutation,
+          {
+            inputs: [
+              await PlanFactory({
+                volumes: [VolumeFactory({ [key]: min - 1 })],
+              }),
+            ],
+          },
+          token,
+        );
+
+        expect(errors).toBeDefined();
+        if (errors) {
+          expect(errors.length).toEqual(1);
+          expect(errors[0].originalError).toBeInstanceOf(ValidationError);
+        }
+      }),
+    );
+  });
+});

--- a/tests/feature/get-plans.test.ts
+++ b/tests/feature/get-plans.test.ts
@@ -1,18 +1,11 @@
 import AuthenticationError from '@src/errors/AuthenticationError';
-import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
 import { PlanFactory } from '@src/factories/PlanFactory';
-import { TrainingFactory } from '@src/factories/TrainingFactory';
-import { VolumeFactory } from '@src/factories/VolumeFactory';
 import { PlanModel } from '@src/models/Plan';
-import { TrainingModel } from '@src/models/Training';
-import { TrainingCategory, TrainingType } from '@src/types/enums';
 import { graphql } from '@tests/graphql';
 import { signIn } from '@tests/helpers';
 
 describe('운동 계획 조회', () => {
   const plansQuery = `query plans { plans { _id } }`;
-  const multipleCreateOrUpdatePlansMutation = `mutation multipleCreateOrUpdatePlans($inputs: [PlanInput!]!) { multipleCreateOrUpdatePlans(inputs: $inputs) { _id, oneRM, volumes { _id } } }`;
-  const getOneRMQuery = `query getOneRM($name: String!) { getOneRM(name: $name) }`;
 
   it('로그인 하지 않은 사용자는 모든 운동 계획을 조회할 수 없다', async () => {
     const { errors } = await graphql(plansQuery);
@@ -36,110 +29,5 @@ describe('운동 계획 조회', () => {
 
     expect(errors).toBeUndefined();
     expect(data?.plans.length).toEqual(count);
-  });
-
-  it('운동 계획이 완료 상태고 중량 볼륨이라면 사용자의 운동 종목에 대한 최대 무게를 조회할 수 있다', async () => {
-    const { token } = await signIn();
-    const createPlanResponse = await graphql(
-      multipleCreateOrUpdatePlansMutation,
-      {
-        inputs: [
-          await PlanFactory({
-            complete: true,
-            volumes: [VolumeFactory({ weight: 100, count: 5 })],
-          }),
-        ],
-      },
-      token,
-    );
-
-    const plan = await PlanModel.findById(
-      createPlanResponse.data?.multipleCreateOrUpdatePlans[0]._id,
-    ).orFail(new DocumentNotFoundError());
-    const training = await TrainingModel.findById(plan.training);
-
-    const { data, errors } = await graphql(
-      getOneRMQuery,
-      {
-        name: training?.name,
-      },
-      token,
-    );
-
-    expect(errors).toBeUndefined();
-    expect(data?.getOneRM).toEqual(
-      createPlanResponse.data?.multipleCreateOrUpdatePlans[0].oneRM,
-    );
-  });
-
-  it('중량 볼륨이고 운동을 완료하지 않았다면 최대 무게를 0으로 반환한다', async () => {
-    const { token } = await signIn();
-    const squatName = '바벨 백스쿼트';
-    const benchPressName = '벤치 프레스';
-    const squat = await TrainingModel.create(
-      TrainingFactory({
-        name: squatName,
-        category: TrainingCategory.WEIGHT,
-        type: TrainingType.LOWER,
-      }),
-    );
-    const benchPress = await TrainingModel.create(
-      TrainingFactory({
-        name: benchPressName,
-        category: TrainingCategory.WEIGHT,
-        type: TrainingType.CHEST,
-      }),
-    );
-    await graphql(
-      multipleCreateOrUpdatePlansMutation,
-      {
-        inputs: [
-          await PlanFactory({
-            training: squat._id.toHexString(),
-            complete: true,
-            volumes: [
-              VolumeFactory({
-                weight: 100,
-                count: 5,
-              }),
-            ],
-          }),
-        ],
-      },
-      token,
-    );
-    await graphql(
-      multipleCreateOrUpdatePlansMutation,
-      {
-        inputs: [
-          await PlanFactory({
-            training: benchPress._id.toHexString(),
-            complete: false,
-            volumes: [
-              VolumeFactory({
-                weight: 100,
-                count: 5,
-              }),
-            ],
-          }),
-        ],
-      },
-      token,
-    );
-
-    const { data, errors } = await graphql(
-      `
-        query SBGetOneRM {
-          squatGetOneRM: getOneRM(name: "${squatName}")
-          benchpressGetOneRM: getOneRM(name: "${benchPressName}")
-        }
-      `,
-      undefined,
-      token,
-    );
-
-    expect(errors).toBeUndefined();
-    expect(data?.squatGetOneRM === 0).toBeFalsy();
-    expect(data?.benchpressGetOneRM === 0).toBeTruthy();
   });
 });

--- a/tests/feature/get-volumes.test.ts
+++ b/tests/feature/get-volumes.test.ts
@@ -1,0 +1,121 @@
+import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
+import { PlanFactory } from '@src/factories/PlanFactory';
+import { TrainingFactory } from '@src/factories/TrainingFactory';
+import { VolumeFactory } from '@src/factories/VolumeFactory';
+import { PlanModel } from '@src/models/Plan';
+import { TrainingModel } from '@src/models/Training';
+import { VolumeModel } from '@src/models/Volume';
+import { TrainingCategory, TrainingType } from '@src/types/enums';
+import { graphql } from '@tests/graphql';
+import { signIn } from '@tests/helpers';
+
+describe('운동 볼륨 조회', () => {
+  const getOneRMQuery = `query getOneRM($name: String!) { getOneRM(name: $name) }`;
+
+  it('운동 볼륨이 완료 상태고 중량 볼륨이라면 사용자의 운동 종목에 대한 최대 무게를 조회할 수 있다', async () => {
+    const { token, user } = await signIn();
+    const training = await TrainingModel.create(TrainingFactory());
+    const [firstPlan] = await PlanModel.multipleCreateOrUpdateWithVolumes(
+      user,
+      [
+        await PlanFactory({
+          training: training._id.toHexString(),
+          volumes: [VolumeFactory({ count: 5, weight: 100, complete: true })],
+        }),
+      ],
+    );
+
+    const firstResponse = await graphql(
+      getOneRMQuery,
+      {
+        name: training.name,
+      },
+      token,
+    );
+
+    expect(firstResponse.errors).toBeUndefined();
+    expect(firstResponse.data?.getOneRM).toEqual(
+      (
+        await VolumeModel.findById(firstPlan.volumes[0])
+          .orFail(new DocumentNotFoundError())
+          .exec()
+      ).oneRM,
+    );
+
+    const [secondPlan] = await PlanModel.multipleCreateOrUpdateWithVolumes(
+      user,
+      [
+        await PlanFactory({
+          training: training._id.toHexString(),
+          volumes: [VolumeFactory({ count: 5, weight: 200, complete: true })],
+        }),
+      ],
+    );
+
+    const secondResponse = await graphql(
+      getOneRMQuery,
+      {
+        name: training.name,
+      },
+      token,
+    );
+
+    expect(secondResponse.errors).toBeUndefined();
+    expect(secondResponse.data?.getOneRM).toEqual(
+      (
+        await VolumeModel.findById(secondPlan.volumes[0])
+          .orFail(new DocumentNotFoundError())
+          .exec()
+      ).oneRM,
+    );
+  });
+
+  it('중량 볼륨이고 운동을 완료하지 않았다면 최대 무게를 0으로 반환한다', async () => {
+    const { token, user } = await signIn();
+    const squatName = '바벨 백스쿼트';
+    const benchPressName = '벤치 프레스';
+    const squat = await TrainingModel.create(
+      TrainingFactory({
+        name: squatName,
+        category: TrainingCategory.WEIGHT,
+        type: TrainingType.LOWER,
+      }),
+    );
+    const benchPress = await TrainingModel.create(
+      TrainingFactory({
+        name: benchPressName,
+        category: TrainingCategory.WEIGHT,
+        type: TrainingType.CHEST,
+      }),
+    );
+    await PlanModel.createWithVolumes(
+      user,
+      await PlanFactory({
+        training: squat._id.toHexString(),
+        volumes: [VolumeFactory({ weight: 100, count: 5, complete: true })],
+      }),
+    );
+    await PlanModel.createWithVolumes(
+      user,
+      await PlanFactory({
+        training: benchPress._id.toHexString(),
+        volumes: [VolumeFactory({ weight: 100, count: 5, complete: false })],
+      }),
+    );
+
+    const { data, errors } = await graphql(
+      `
+        query SBGetOneRM {
+          squatGetOneRM: getOneRM(name: "${squatName}")
+          benchpressGetOneRM: getOneRM(name: "${benchPressName}")
+        }
+      `,
+      undefined,
+      token,
+    );
+
+    expect(errors).toBeUndefined();
+    expect(data?.squatGetOneRM === 0).toBeFalsy();
+    expect(data?.benchpressGetOneRM === 0).toBeTruthy();
+  });
+});

--- a/tests/unit/plan.test.ts
+++ b/tests/unit/plan.test.ts
@@ -1,4 +1,3 @@
-import DocumentNotFoundError from '@src/errors/DocumentNotFoundError';
 import { PlanFactory } from '@src/factories/PlanFactory';
 import { VolumeFactory } from '@src/factories/VolumeFactory';
 import { Model } from '@src/models/Model';
@@ -26,20 +25,5 @@ describe('운동계획 모델', () => {
     await PlanModel.findByIdAndDelete(plan._id);
 
     expect(await VolumeModel.count()).toEqual(0);
-  });
-
-  it('운동 계획을 생성할 때 1rm을 저장하는 훅이 있다', async () => {
-    const { user } = await signIn();
-    const { _id } = await PlanModel.createWithVolumes(
-      user,
-      await PlanFactory({
-        volumes: [VolumeFactory({ weight: 100, count: 5 })],
-      }),
-    );
-
-    expect(
-      (await PlanModel.findById(_id).orFail(new DocumentNotFoundError()).exec())
-        .oneRM !== 0,
-    ).toBeTruthy();
   });
 });

--- a/tests/unit/volume.test.ts
+++ b/tests/unit/volume.test.ts
@@ -11,21 +11,20 @@ describe('운동볼륨 모델', () => {
     expect(Object.getPrototypeOf(Volume)).toEqual(Model);
   });
 
-  it('중량 볼륨을 생성할 때 총볼륨을 저장하는 훅이 있다', async () => {
+  it('중량 볼륨을 생성할 때 총볼륨과 1rm을 저장하는 훅이 있다', async () => {
     const { user } = await signIn();
     const plan = await PlanModel.createWithVolumes(
       user,
       await PlanFactory({
-        volumes: [VolumeFactory({ weight: 100, count: 5 })],
+        volumes: [VolumeFactory({ weight: 100, count: 5, complete: true })],
       }),
     );
 
-    expect(
-      (
-        await VolumeModel.findById(plan.volumes[0]?._id)
-          .orFail(new DocumentNotFoundError())
-          .exec()
-      ).total !== 0,
-    ).toBeTruthy();
+    const volume = await VolumeModel.findById(plan.volumes[0]?._id)
+      .orFail(new DocumentNotFoundError())
+      .exec();
+
+    expect(volume.total !== 0).toBeTruthy();
+    expect(volume.oneRM !== 0).toBeTruthy();
   });
 });


### PR DESCRIPTION
### 작업 개요
- `Plan` 모델의 `complete`를 제거하고 `Volume` 모델에 추가하여 운동 볼륨 단위로 완료를 확인할 수 있도록 한다.
- `getOneRM` `query`가 `PlanResolver`에서 해결하고 있는 것을 `VolumeResolver`에서 해결하도록 변경

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경

### 작업 상세 내용
- `Plan` 모델의 `complete`, `oneRM` 속성 제거
    - `PlanFactory`, `PlanInput`
    - `Plan` 모델의 `setOneRM` 훅 제거
    - `PlanResolver` `getOneRM` 쿼리 제거
    - 관련 테스트 제거
- `Volume` 모델의 `complete`, `oneRM` 속성 추가
    - `VolumeFactory`, `VolumeInput`
    - `Volume`모델의 `setOneRMWithTotal` 훅 추가
    - `VolumeResolver` `getOneRM` 쿼리 추가
    - 관련 테스트 추가

resolve #131

