### PR TITLE
[fix] Document 삭제시 pre훅 동작하지 않음

### DIFF
--- a/src/resolvers/PlanResolver.ts
+++ b/src/resolvers/PlanResolver.ts
@@ -63,11 +63,11 @@ export class PlanResolver implements ResolverInterface<Plan> {
       throw new AuthenticationError();
     }
 
-    await (
+    (
       await PlanModel.findById(_id).orFail(new DocumentNotFoundError()).exec()
-    )
-      .checkPermission(user)
-      .deleteOne();
+    ).checkPermission(user);
+
+    await PlanModel.findOneAndDelete({ _id });
 
     return true;
   }

--- a/src/resolvers/TrainingResolver.ts
+++ b/src/resolvers/TrainingResolver.ts
@@ -42,9 +42,7 @@ export class TrainingResolver {
   async deleteTraining(
     @Arg('_id') _id: mongoose.Types.ObjectId,
   ): Promise<boolean> {
-    await TrainingModel.findByIdAndDelete(_id)
-      .orFail(new DocumentNotFoundError())
-      .exec();
+    await TrainingModel.findOneAndDelete({ _id });
 
     return true;
   }


### PR DESCRIPTION
### 작업 개요
`Plan`, `Training`모델 삭제 리졸버에서 `Document` 삭제가 아닌 `Modal` 삭제로 변경

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경

resolve #135

